### PR TITLE
Hotfix/default distance prior

### DIFF
--- a/fitter/probabilities/priors.py
+++ b/fitter/probabilities/priors.py
@@ -232,7 +232,7 @@ DEFAULT_PRIORS = {
     'a2': UniformPrior('a2', [(0, 6), ('>=', 'a1')]),
     'a3': UniformPrior('a3', [(1.6, 6), ('>=', 'a2')]),
     'BHret': UniformPrior('BHret', [(0, 100)]),
-    'd': GaussianPrior('d', mu=DEFAULT_INITIALS['d'], sigma=0.5),
+    'd': GaussianPrior('d', mu=DEFAULT_INITIALS['d'], sigma=0.05),
 }
 
 _PRIORS_MAP = {


### PR DESCRIPTION
Tweak the width of the default Gaussian prior on the distance, from the arbitrary 0.5 we had before to ~50 parsecs, which is much closer to the usual error bars on cluster distances.

I would recommend, however, that users supply a custom priors JSON to any runs with the specific GAIA distance values and errors, to be even more accurate.