### PR TITLE
fix autocorr computation/logs for too short chains

### DIFF
--- a/fitter/core/main.py
+++ b/fitter/core/main.py
@@ -310,13 +310,14 @@ def fit(cluster, Niters, Nwalkers, Ncpu=2, *,
                     shutil.copyfile(f"{savedir}/{cluster}_sampler.hdf",
                                     f"{savedir}/.backup_{cluster}_sampler.hdf")
 
-        try:
-            # Attempt to get autocorrelation time
-            tau = sampler.get_autocorr_time()
-        except emcee.autocorr.AutocorrError:
-            tau = np.nan
+        # Attempt to get autocorrelation time
+        tau = sampler.get_autocorr_time(quiet=True)
 
-    logging.info(f'Autocorrelation time: {tau}')
+        logging.info(f'Autocorrelation times: {tau}')
+
+        if ((τ := tau.max()) * 50) > sampler.iteration:
+            logging.warning('Chain not long enough for reliable autocorrelation'
+                            f', should run for atleast {50 * τ=:g} iterations.')
 
     logging.info("Finished iteration")
 
@@ -332,6 +333,7 @@ def fit(cluster, Niters, Nwalkers, Ncpu=2, *,
 
         meta_grp.attrs['runtime'] = time.time() - t0
         meta_grp.attrs['autocorr'] = tau
+        meta_grp.attrs['reliable_autocorr'] = np.any((tau * 50) > Niters)
 
         # Store run statistics
 


### PR DESCRIPTION
Fix the computation of the integrated autocorrelation time we use after the sampling run, which was always failing as our chains are typically too short to reliable compute this time. We no suppress the errors this would typically raise and handle that warning explicitly.

This doesn't change the fact that our chains seem to be way too small to give a happy autocorrelation, of course.