### PR TITLE
change default distance prior to `UniformPrior`

### DIFF
--- a/fitter/probabilities/priors.py
+++ b/fitter/probabilities/priors.py
@@ -232,7 +232,7 @@ DEFAULT_PRIORS = {
     'a2': UniformPrior('a2', [(0, 6), ('>=', 'a1')]),
     'a3': UniformPrior('a3', [(1.6, 6), ('>=', 'a2')]),
     'BHret': UniformPrior('BHret', [(0, 100)]),
-    'd': GaussianPrior('d', mu=DEFAULT_INITIALS['d'], sigma=0.05),
+    'd': UniformPrior('d', [(2, 8)])
 }
 
 _PRIORS_MAP = {


### PR DESCRIPTION
As it makes no sense for a gaussian prior with a specified centre
to be used as the default for any cluster, and in fact a lot of
the time it would actually be invalid.