### PR TITLE
Fix scipy trapezoind import

### DIFF
--- a/fitter/util/probabilities.py
+++ b/fitter/util/probabilities.py
@@ -94,11 +94,11 @@ def trim_peaks(az_domain, Paz):
     or the normalization drops too much.
     """
     from scipy.signal import find_peaks
-    from scipy.integrate import trapezoid
+    from scipy.integrate import trapz
 
     Paz = Paz.copy()
 
-    while (area := trapezoid(x=az_domain.value, y=Paz.value)) >= 0.98:
+    while (area := trapz(x=az_domain.value, y=Paz.value)) >= 0.98:
 
         peaks, _ = find_peaks(Paz, height=0, threshold=1e5, width=1)
 


### PR DESCRIPTION
It seems like the version of `scipy` that's on Compute Canada doesn't have `trapezoid` and `trapz` aliased, this should fix it.