### PR TITLE
update `setup.py` to require version 1.3 of `gala`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 
 # Package information
 NAME = 'GCfit'
-VERSION = "0.6.5"
+VERSION = "0.6.6"
 
 DESCRIPTION = 'Multimass MCMC fitting of Limepy globular cluster analytic model'
 with io.open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
@@ -31,7 +31,7 @@ REQUIRED = [
     "scipy",
     "h5py",
     "tqdm",
-    "gala",
+    "gala==1.3",
     "shapely"
 ]
 


### PR DESCRIPTION
The newest version of `gala` seems to be having some trouble compiling with GSL support enabled (see discussion at #46).
The easiest solution is to ensure, for the time being, that the previous version (1.3) is the version of gala used.

This is not a wonderful solution, requiring an old dependency version is messy, but for now it will work.