### PR TITLE
copy `filter_likelihoods` method to `nested_fit`

### DIFF
--- a/fitter/core/main.py
+++ b/fitter/core/main.py
@@ -702,15 +702,7 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
 
     logging.debug(f"Observation datasets: {observations}")
 
-    likelihoods = []
-    for component in observations.valid_likelihoods:
-        key, func, *_ = component
-        func_name = func.__name__
-
-        if not any(fnmatch(key, pattern) or fnmatch(func_name, pattern)
-                   for pattern in excluded_likelihoods):
-
-            likelihoods.append(component)
+    likelihoods = observations.filter_likelihoods(excluded_likelihoods, True)
 
     logging.debug(f"Likelihood components: {likelihoods}")
 


### PR DESCRIPTION
Just an oversight during the nested sampling addition, the new
`filter_*` methods from `Observations` are sporadically missing.
This logic was replaced in the MCMC fit but not the nested fit.