### PR TITLE
add `maxfrac` as an optional run parameter

### DIFF
--- a/bin/GCfitter
+++ b/bin/GCfitter
@@ -129,6 +129,10 @@ if __name__ == '__main__':
                              help='Posterior weighting fraction f_p')
     parser_nest.add_argument('--dlogz', default=0.25, type=float,
                              help='Δln(Z) tolerance initial stopping condition')
+    parser_nest.add_argument('--maxfrac', default=0.8, type=float,
+                             help='The fractional threshold, relative to the '
+                                  'peak weight, used to determine likelihood '
+                                  'bounds for dynamic sampling. Default to 80%')
     parser_nest.add_argument('--eff-samples', default=5000, type=pos_int,
                              help='Number of effective posterior samples '
                                   'stopping condition')


### PR DESCRIPTION
In an attempt to get dynamic sampling to begin for some of the
struggling clusters, we may need to (somewhat drastically)
decrease `maxfrac`, therefore it should be a configurable param.