### PR TITLE
Hotfix/max logl bound

### DIFF
--- a/fitter/util/probabilities.py
+++ b/fitter/util/probabilities.py
@@ -175,14 +175,12 @@ def plateau_weight_function(results, args=None, return_weights=False):
         nsamps = weight.size
 
         # A temporary test to handle weight jumps due to plateaus
-        max_bound = (nsamps - 1) - results.samples_n.max()
+        # TODO emphasis on the *temporary* here, this is ugly (10)
+        max_bound = (nsamps - 1) - results.samples_n[0]
 
         # overflow on the RHS, so we move the left side
-        if bounds[1] > nsamps - 1:
-            bounds = [bounds[0] - (bounds[1] - (nsamps - 1)), max_bound]
-
-        elif bounds[1] == nsamps - 1:
-            bounds[1] = max_bound
+        if bounds[1] >= max_bound:
+            bounds = [bounds[0] - (bounds[1] - max_bound), max_bound]
 
         return bounds, weight
 
@@ -212,7 +210,8 @@ def plateau_weight_function(results, args=None, return_weights=False):
 
     # If this is overflowing on the right, recompute with a much lower fraction
     # Won't change the bound, but is a hacky way to hopefully get a better LHS
-    if bounds[1] == (logl.size - 1) - results.samples_n.max():
+    # TODO must be better way to determine if we've gone left of wt peak or not
+    if bounds[1] == (logl.size - 1) - results.samples_n[0]:
         bounds, weight = compute_bounds(bound_frac=0.25 * maxfrac)
 
     # if we overflow on the leftside we set the edge to -inf and expand the RHS


### PR DESCRIPTION
Attempts to fix our already shaky max logl bound fixes by using some slightly earlier logl value as the max upper bound, rather than simply the absolute max logl ever reached.

This wouldn't always work as the upper bound actually needs to be crossed `Nlive-1` times before the stopping condition was reached, so if it was set to max we were hitting the same plateau that started this whole mess.