### PR TITLE
fix bug with verbose printing at end of runs

### DIFF
--- a/fitter/core/main.py
+++ b/fitter/core/main.py
@@ -619,7 +619,7 @@ def MCMC_fit(cluster, Niters, Nwalkers, Ncpu=2, *,
 
     if verbose:
         from .. import visualize as viz
-        viz.RunVisualizer(backend_fn, observations).print_summary()
+        viz.MCMCVisualizer(backend_fn, observations).print_summary()
 
     logging.info("FINISHED")
 
@@ -961,6 +961,6 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
 
     if verbose:
         from .. import visualize as viz
-        viz.RunVisualizer(backend_fn, observations).print_summary()
+        viz.NestedVisualizer(backend_fn, observations).print_summary()
 
     logging.info("FINISHED")


### PR DESCRIPTION
Missed the change from `RunVisualizer` to new specific visualizers. Hadn't run into it before because we'd never had successful runs until now.