### PR TITLE
restrict IMF exponent priors to physical values

### DIFF
--- a/fitter/probabilities/priors.py
+++ b/fitter/probabilities/priors.py
@@ -456,9 +456,9 @@ DEFAULT_PRIORS = {
     'delta': ('uniform', [(0.3, 0.5)]),
     's2': ('uniform', [(0, 15)]),
     'F': ('uniform', [(1, 3)]),
-    'a1': ('uniform', [(0, 6)]),
-    'a2': ('uniform', [(0, 6), ('a1', np.inf)]),
-    'a3': ('uniform', [(1.6, 6), ('a2', np.inf)]),
+    'a1': ('uniform', [(0, 2.35)]),
+    'a2': ('uniform', [(0, 2.35), ('a1', np.inf)]),
+    'a3': ('uniform', [(1.6, 4), ('a2', np.inf)]),
     'BHret': ('uniform', [(0, 100)]),
     'd': ('uniform', [(2, 8)])
 }


### PR DESCRIPTION
The uniform prior bounds on all alpha parameters are restricted
to smaller regions, which can be more easily justified through
physical means.

The low-mass components are restricted to an upper bound of the
Salpeter 2.35, which no other IMF formulation is ever higher than,
in the low-mass regime.

The high-mass component has it's upper bound lowered to 4. This was
determined to be slightly above the exponent which, in the lowest
mass possible clusters, will still allow for any remnants. Models
completely devoid of remnants are likely unphysical, and thus an
upper bound of 4 is plenty high. Final fits which result in a3>3.5
should probably be investigated manually anyways, and maybe have
this bound further reduced.