### PR TITLE
fix PM ratio divide-by-zero bug at edge of models

### DIFF
--- a/fitter/probabilities/probabilities.py
+++ b/fitter/probabilities/probabilities.py
@@ -678,6 +678,9 @@ def likelihood_pm_ratio(model, pm, *, mass_bin=None, hyperparams=False):
     # Get model values
     model_ratio = np.sqrt(model.v2Tj[mass_bin] / model.v2Rj[mass_bin])
 
+    # Fix the occasional 0/0 error at the edge of the model
+    model_ratio[np.isnan(model_ratio)] = 1.0
+
     # Convert model units
     model_r = model.r.to(pm['r'].unit)
 


### PR DESCRIPTION
In some models the velocity fields (v2Tj, v2Rj) are 0 at the very
edge, and thus the computed anisotropy ratio T/R is NaN. This
messed up the interpolation completely, and caused the posterior
to fail.

This fix simply sets the NaN ratio to 1. In the future, when the
interpolation methods are improved in the likelihood functions,
this might not be necessary, but this fix will be okay for now
as the models should always be isotropic in the edges anyways.