### PR TITLE
add fix for finding resources within a directory

### DIFF
--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -424,8 +424,11 @@ def field_Pdot_KDE(*, pulsar_db='field_msp.dat', corrected=True):
     psrcat -db_file psrcat.db -c "p0 p1 p1_i GB GL Dist" -l "p0 < 0.1 &&
         p1 > 0 && p1_i > 0 && ! assoc(GC)" -x > field_msp.dat
     '''
+    from ..util.data import _open_resources
+
     # Get field pulsars data
-    with resources.path('fitter', 'resources') as datadir:
+
+    with _open_resources() as datadir:
         pulsar_db = pathlib.Path(f"{datadir}/{pulsar_db}")
         cols = (0, 3, 6, 7, 8, 9)
         P, Pdot, Pdot_pm, lat, lon, D = np.genfromtxt(pulsar_db, usecols=cols).T

--- a/fitter/util/data.py
+++ b/fitter/util/data.py
@@ -105,7 +105,6 @@ def core_cluster_list():
     '''Return a list of cluster names, useable by `fitter.Observations`'''
     
     with _open_resources() as datadir:
-
         return [f.stem for f in pathlib.Path(datadir).glob('[!TEST]*.hdf')]
 
 
@@ -186,7 +185,6 @@ def hdf_view(cluster, attrs=False, spacing='normal', *, outfile="stdout"):
 
     # TODO use get_std_cluster_name here
     with _open_resources() as datadir:
-
         with h5py.File(f'{datadir}/{cluster}.hdf', 'r') as file:
 
             out = f"{f' {cluster} ':=^40}\n\n"
@@ -1090,7 +1088,6 @@ class ClusterFile:
         '''make all checks of this dataset'''
 
         with _open_resources() as datadir:
-
             with open(f'{datadir}/specification.json') as ofile:
                 fullspec = json.load(ofile)
 
@@ -1152,7 +1149,6 @@ class ClusterFile:
         '''make all checks of these initials'''
 
         with _open_resources() as datadir:
-
             with open(f'{datadir}/specification.json') as ofile:
                 init_spec = json.load(ofile)['INITIALS']
 

--- a/fitter/util/data.py
+++ b/fitter/util/data.py
@@ -6,7 +6,6 @@ import shutil
 import pathlib
 import logging
 import fnmatch
-from importlib import resources
 
 import h5py
 import numpy as np
@@ -85,10 +84,26 @@ def bibcode2cite(bibcode):
 # Data file utilities
 # --------------------------------------------------------------------------
 
+def _open_resources():
+    '''Quick and dirty backwards-compatible solution to resources in directories
+    See github.com/python/importlib_resources/issues/58 and
+    bugs.python.org/issue44162 for more detail
+    '''
+    from importlib import resources
+
+    try:
+        # Python >= 3.9
+        return resources.files('fitter') / 'resources'
+
+    except AttributeError:
+        # Python >= 3.7
+        # we don't support lower than 3.7 (when resources was added) anyways
+        return resources.path('fitter', 'resources')
+
 
 def core_cluster_list():
     '''Return a list of cluster names, useable by `fitter.Observations`'''
-    with resources.path('fitter', 'resources') as datadir:
+    with _open_resources() as datadir:
         return [f.stem for f in pathlib.Path(datadir).glob('[!TEST]*.hdf')]
 
 
@@ -168,7 +183,7 @@ def hdf_view(cluster, attrs=False, spacing='normal', *, outfile="stdout"):
     # ----------------------------------------------------------------------
 
     # TODO use get_std_cluster_name here
-    with resources.path('fitter', 'resources') as datadir:
+    with _open_resources() as datadir:
         with h5py.File(f'{datadir}/{cluster}.hdf', 'r') as file:
 
             out = f"{f' {cluster} ':=^40}\n\n"
@@ -366,7 +381,7 @@ def get_cluster_path(name, standardize_name=True, restrict_to='local'):
     # Get full paths to each file
     local_file = pathlib.Path(local_dir, filename)
 
-    with resources.path('fitter', 'resources') as core_dir:
+    with _open_resources() as core_dir:
         core_file = pathlib.Path(core_dir, std_filename)
 
     # ----------------------------------------------------------------------
@@ -497,7 +512,7 @@ class ClusterFile:
             logging.info(f'{name} is a core cluster, making a new local copy')
 
             # TODO Add a flag that this is a local file? or only n Observations?
-            with resources.path('fitter', 'resources') as core_dir:
+            with _open_resources() as core_dir:
                 core_file = pathlib.Path(core_dir, name).with_suffix('.hdf')
                 shutil.copyfile(core_file, local_file)
 
@@ -1069,7 +1084,7 @@ class ClusterFile:
     def _test_dataset(self, key, dataset):
         '''make all checks of this dataset'''
 
-        with resources.path('fitter', 'resources') as datadir:
+        with _open_resources() as datadir:
             with open(f'{datadir}/specification.json') as ofile:
                 fullspec = json.load(ofile)
 
@@ -1105,7 +1120,7 @@ class ClusterFile:
     def _test_metadata(self, metadata):
         '''make all checks of this metadata'''
 
-        with resources.path('fitter', 'resources') as datadir:
+        with _open_resources() as datadir:
             with open(f'{datadir}/specification.json') as ofile:
                 mdata_spec = json.load(ofile)['METADATA']
 
@@ -1129,7 +1144,7 @@ class ClusterFile:
     def _test_initials(self, initials):
         '''make all checks of these initials'''
 
-        with resources.path('fitter', 'resources') as datadir:
+        with _open_resources() as datadir:
             with open(f'{datadir}/specification.json') as ofile:
                 init_spec = json.load(ofile)['INITIALS']
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ REQUIRED = [
     "h5py",
     "tqdm",
     "dynesty",
-    "gala",
+    "gala==1.3",
     "shapely",
     "sphinx-toggleprompt"
 ]


### PR DESCRIPTION
Creates a simple, backwards-compatible, function for reading in
a full resource directory. This was only accidentally supported
before 3.9, and the old way of doing it now raises an exception.

As long as we support python3.8, a hybrid fix like this is needed.