### PR TITLE
fix bug in storage of new variable units

### DIFF
--- a/fitter/util/data.py
+++ b/fitter/util/data.py
@@ -1335,7 +1335,7 @@ class Dataset:
         # Store all data in the variables dict
         self.variables[varname] = {
             "data": data,
-            "unit": unit,
+            "unit": str(unit) if unit is not None else None,
             "metadata": metadata
         }
 


### PR DESCRIPTION
While it was nominally supported, attempting to store astropy unit
objects entirely was an HDF bug. This simply makes sure it's
stored as the correct string (or None)