### PR TITLE
change upper bound on g priors to 3.5

### DIFF
--- a/fitter/probabilities/priors.py
+++ b/fitter/probabilities/priors.py
@@ -654,7 +654,7 @@ DEFAULT_PRIORS = {
     'M': ('uniform', [(0.01, 5)]),
     'rh': ('uniform', [(0.5, 15)]),
     'ra': ('uniform', [(0, 5)]),
-    'g': ('uniform', [(0, 2.3)]),
+    'g': ('uniform', [(0, 3.5)]),
     'delta': ('uniform', [(0.3, 0.5)]),
     's2': ('uniform', [(0, 15)]),
     'F': ('uniform', [(1, 3)]),


### PR DESCRIPTION
This is the actual upper bound value possible with finite
extent models, and should be, at least, the default on the priors.
2.3 came from the 47-Tuc paper, and is in most cases a reasonable
bound (See Peuten et al. 2017), but there's no reason to be
restrictive by default.