### PR TITLE
Feature/remnant fraction

### DIFF
--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -2677,6 +2677,18 @@ class ModelCollection:
     # Collection Attributes
     # ----------------------------------------------------------------------
 
+    # TODO technically all of these could be defined as singles for modelviz
+
+    @property
+    def f_rem(self):
+
+        if not self._ci:
+            mssg = ("'ModelCollection' object has no attribute 'f_rem'. "
+                    "Must be constructed with CIModelVisualizer objects.")
+            raise AttributeError(mssg)
+
+        return [mv.f_rem for mv in self.visualizers]
+
     @property
     def BH_mass(self):
 

--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -2373,6 +2373,9 @@ class CIModelVisualizer(_ClusterVisualizer):
 
             quant_grp = modelgrp.create_group('quantities')
 
+            ds = quant_grp.create_dataset('f_rem', data=self.f_rem)
+            ds.attrs['unit'] = self.f_rem.unit.to_string()
+
             ds = quant_grp.create_dataset('BH_mass', data=self.BH_mass)
             ds.attrs['unit'] = self.BH_mass.unit.to_string()
 

--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -1621,6 +1621,8 @@ class ModelVisualizer(_ClusterVisualizer):
         self.star_bin = model.nms - 1
         self.mj = model.mj
 
+        self.f_rem = np.sum(model.Mj[model._remnant_bins]) / model.M
+
         self.LOS = np.sqrt(self.model.v2pj)[:, np.newaxis, :]
         self.pm_T = np.sqrt(model.v2Tj)[:, np.newaxis, :]
         self.pm_R = np.sqrt(model.v2Rj)[:, np.newaxis, :]

--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -1370,7 +1370,7 @@ class _ClusterVisualizer:
         return fig
 
     @_support_units
-    def plot_remnant_fraction(self, fig=None, ax=None, *,
+    def plot_remnant_fraction(self, fig=None, ax=None, *, show_total=True,
                               x_unit='pc', label_position='left'):
         '''Fraction of mass in remnants vs MS stars, like in baumgardt'''
 
@@ -1390,6 +1390,15 @@ class _ClusterVisualizer:
         self._set_xlabel(ax)
 
         ax.set_ylim(0.0, 1.0)
+
+        if show_total:
+            from matplotlib.offsetbox import AnchoredText
+
+            tot = AnchoredText(fr'$f_{{\mathrm{{remn}}}}={self.f_rem:.2f}$',
+                               frameon=True, loc='upper center')
+
+            tot.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
+            ax.add_artist(tot)
 
         ax.legend()
 
@@ -1810,6 +1819,19 @@ class CIModelVisualizer(_ClusterVisualizer):
     class for making, showing, saving all the plots related to a bunch of models
     in the form of confidence intervals
     '''
+
+    @_ClusterVisualizer._support_units
+    def plot_f_rem(self, fig=None, ax=None, bins='auto', color='b'):
+
+        fig, ax = self._setup_artist(fig, ax)
+
+        color = mpl_clr.to_rgb(color)
+        facecolor = color + (0.33, )
+
+        ax.hist(self.f_rem, histtype='stepfilled',
+                bins=bins, ec=color, fc=facecolor, lw=2)
+
+        return fig
 
     @_ClusterVisualizer._support_units
     def plot_BH_mass(self, fig=None, ax=None, bins='auto', color='b'):

--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -1939,6 +1939,8 @@ class CIModelVisualizer(_ClusterVisualizer):
         frac_M_MS = np.full((1, N, Nr), np.nan) << u.dimensionless_unscaled
         frac_M_rem = frac_M_MS.copy()
 
+        f_rem = np.full(N, np.nan) << u.dimensionless_unscaled
+
         # number density
 
         numdens = np.full((1, N, Nr), np.nan) << u.pc**-2
@@ -2037,6 +2039,8 @@ class CIModelVisualizer(_ClusterVisualizer):
 
             frac_M_MS[slc], frac_M_rem[slc] = viz._init_mass_frac(model)
 
+            f_rem[model_ind] = np.sum(model.Mj[model._remnant_bins]) / model.M
+
             # Black holes
 
             BH_mass[model_ind] = np.sum(model.BH_Mj)
@@ -2087,6 +2091,8 @@ class CIModelVisualizer(_ClusterVisualizer):
 
         viz.frac_M_MS = perc(frac_M_MS, q, axis=1)
         viz.frac_M_rem = perc(frac_M_rem, q, axis=1)
+
+        viz.f_rem = f_rem
 
         viz.BH_mass = BH_mass
         viz.BH_num = BH_num

--- a/fitter/analysis/runs.py
+++ b/fitter/analysis/runs.py
@@ -2234,6 +2234,7 @@ class RunCollection(_RunAnalysis):
             'chi2': r'$\chi^2$',
             'BH_mass': r'$\mathrm{M}_{BH}\ [M_\odot]$',
             'BH_num': r'$\mathrm{N}_{BH}$',
+            'f_rem': r'$f_{\mathrm{remn}}$',
         }
 
         return math_mapping.get(param, param)
@@ -2604,7 +2605,7 @@ class RunCollection(_RunAnalysis):
             labels = ['FeHe'] + labels
 
         if include_BH:
-            labels += ['BH_mass', 'BH_num']
+            labels += ['BH_mass', 'BH_num', 'f_rem']
 
         # Fill in a dictionary of column data
 


### PR DESCRIPTION
Add mass fraction in remnants (single quantity) to all models and collections.
While a very similar thing already existed in the `frac_M_*` profiles, this new quantity is a single "total" value for the entire model, and can more usefully be compared against values reported in say Sollima & Baumgardt (2017).