### PR TITLE
Hotfix/ra units

### DIFF
--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -1618,7 +1618,7 @@ class ModelVisualizer(_ClusterVisualizer):
         self.ra = model.ra
         self.rt = model.rt
         self.F = model.F
-        self.s2 = model.s2
+        self.s2 = model._theta['s2']
         self.d = model.d
 
         self.r = model.r

--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -1618,7 +1618,7 @@ class ModelVisualizer(_ClusterVisualizer):
         self.ra = model.ra
         self.rt = model.rt
         self.F = model.F
-        self.s2 = model._theta['s2']
+        self.s2 = model.theta['s2']
         self.d = model.d
 
         self.r = model.r

--- a/fitter/analysis/runs.py
+++ b/fitter/analysis/runs.py
@@ -354,7 +354,7 @@ class MCMCRun(_RunAnalysis):
                 'W0': r'$\phi_0$',
                 'M': r'$M$',
                 'rh': r'$r_h$',
-                'ra': r'$r_a$',
+                'ra': r'$\log\left(r_a\right)$',
                 'g': r'$g$',
                 'delta': r'$\delta$',
                 's2': r'$s^2$',
@@ -1002,13 +1002,14 @@ class NestedRun(_RunAnalysis):
 
         labels = list(self.obs.initials)
 
+        # TODO make sure all plots are showing math, units and stuff in labels
         if math_labels:
 
             math_mapping = {
                 'W0': r'$\phi_0$',
                 'M': r'$M$',
                 'rh': r'$r_h$',
-                'ra': r'$r_a$',
+                'ra': r'$\log\left(r_a\right)$',
                 'g': r'$g$',
                 'delta': r'$\delta$',
                 's2': r'$s^2$',
@@ -2217,7 +2218,7 @@ class RunCollection(_RunAnalysis):
             'W0': r'$\phi_0$',
             'M': r'$M\ [10^6 M_\odot]$',
             'rh': r'$r_h\ [\mathrm{pc}]$',
-            'ra': r'$r_a\ [\mathrm{pc}]$',
+            'ra': r'$\log\left(r_a/\mathrm{pc}\right)$',
             'g': r'$g$',
             'delta': r'$\delta$',
             's2': r'$s^2$',

--- a/fitter/core/data.py
+++ b/fitter/core/data.py
@@ -811,12 +811,13 @@ class Model(lp.limepy):
         self.r <<= R_units
         self.rh <<= R_units
         self.rt <<= R_units
-        # self.ra <<= u.dimensionless_unscaled  # θ ra is log, model is linear
         self.ra <<= R_units
+        self.rs <<= R_units
 
         self.v2Tj <<= V2_units
         self.v2Rj <<= V2_units
         self.v2pj <<= V2_units
+        self.s2 <<= V2_units
 
         self.rhoj <<= (M_units / R_units**3)
         self.Sigmaj <<= (M_units / R_units**2)
@@ -917,12 +918,6 @@ class Model(lp.limepy):
             verbose=verbose,
         )
 
-        # fix a couple of conflicted attributes
-        self.s2 = self._theta['s2']
-        self.Nj = self.Mj / self.mj
-        # TODO not really sure what the limepy.ra corresponds to right now
-        # self.ra = 10**self._theta['ra']
-
         # ------------------------------------------------------------------
         # Assign units to model values
         # ------------------------------------------------------------------
@@ -932,6 +927,8 @@ class Model(lp.limepy):
         # ------------------------------------------------------------------
         # Split apart the stellar classes of the mass bins
         # ------------------------------------------------------------------
+
+        self.Nj = self.Mj / self.mj
 
         # TODO slight difference in mf.IFMR.mBH_min and mf.mBH_min?
         self._mBH_min = self._mf.IFMR.mBH_min << u.Msun

--- a/fitter/core/data.py
+++ b/fitter/core/data.py
@@ -922,6 +922,8 @@ class Model(lp.limepy):
 
         self._assign_units()
 
+        self.unscaled_ra = self.ra / self.rs
+
         # ------------------------------------------------------------------
         # Split apart the stellar classes of the mass bins
         # ------------------------------------------------------------------

--- a/fitter/core/data.py
+++ b/fitter/core/data.py
@@ -901,7 +901,7 @@ class Model(lp.limepy):
         # Create the limepy model base
         # ------------------------------------------------------------------
 
-        super().__init__(
+        self._limepy_kwargs = dict(
             phi0=self.W0,
             g=self.g,
             M=self.M * 1e6,
@@ -913,6 +913,8 @@ class Model(lp.limepy):
             project=True,
             verbose=verbose,
         )
+
+        super().__init__(**self._limepy_kwargs)
 
         # ------------------------------------------------------------------
         # Assign units to model values

--- a/fitter/core/data.py
+++ b/fitter/core/data.py
@@ -716,14 +716,14 @@ class Model(lp.limepy):
     limepy : Distribution-function model base of this class
     '''
 
-    def _init_mf(self):
+    def _init_mf(self, a1, a2, a3, BHret):
         '''Evolve the cluster mass function from it's IMF using `ssptools`'''
 
         # TODO before comparing with Kroupa we might want to discuss these:
         m123 = [0.1, 0.5, 1.0, 100]  # Slope breakpoints for imf
         nbin12 = [5, 5, 20]
 
-        a12 = [-self.a1, -self.a2, -self.a3]  # Slopes for imf
+        a12 = [-a1, -a2, -a3]  # Slopes for imf
 
         # TODO figure out which of these are cluster dependant, store in hdfs
 
@@ -732,7 +732,7 @@ class Model(lp.limepy):
         tcc = 0  # Core collapse time
         NS_ret = 0.1  # Initial neutron star retention
         BH_ret_int = 1  # Initial Black Hole retention
-        BH_ret_dyn = self.BHret / 100  # Dynamical Black Hole retention
+        BH_ret_dyn = BHret / 100  # Dynamical Black Hole retention
 
         natal_kicks = True
 
@@ -840,10 +840,9 @@ class Model(lp.limepy):
             mssg = f"Missing required params: {missing_params}"
             raise KeyError(mssg)
 
-        self._theta = theta
+        self.theta = theta
 
-        for key, val in self._theta.items():
-            setattr(self, key, val)
+        self.d = theta['d']
 
         # ------------------------------------------------------------------
         # Get mass function
@@ -852,7 +851,8 @@ class Model(lp.limepy):
         # TODO I think how we are handling everything with mj and bins could
         #   be done much more nicely (maybe with some sweet masked arrays)
 
-        self._mf = self._init_mf()
+        self._mf = self._init_mf(theta['a1'], theta['a2'], theta['a3'],
+                                 theta['BHret'])
 
         # Set bins that should be empty to empty
         cs = self._mf.Ns[-1] > 10 * self._mf.Nmin
@@ -902,12 +902,12 @@ class Model(lp.limepy):
         # ------------------------------------------------------------------
 
         self._limepy_kwargs = dict(
-            phi0=self.W0,
-            g=self.g,
-            M=self.M * 1e6,
-            rh=self.rh,
-            ra=10**self.ra,
-            delta=self.delta,
+            phi0=theta['W0'],
+            g=theta['g'],
+            M=theta['M'] * 1e6,
+            rh=theta['rh'],
+            ra=10**theta['ra'],
+            delta=theta['delta'],
             mj=mj,
             Mj=Mj,
             project=True,

--- a/fitter/core/data.py
+++ b/fitter/core/data.py
@@ -781,10 +781,6 @@ class Model(lp.limepy):
             vesc=vesc
         )
 
-    # def _get_scale(self):
-    #     TODO I have no idea how the scaling is supposed to work in limepy
-    #     G_scale, M_scale, R_scale = self._GS, self._MS, self._RS
-
     def _assign_units(self):
         '''Convert most values to `astropy.Quantity` with correct units'''
 

--- a/fitter/core/data.py
+++ b/fitter/core/data.py
@@ -811,6 +811,7 @@ class Model(lp.limepy):
         self.r <<= R_units
         self.rh <<= R_units
         self.rt <<= R_units
+        # self.ra <<= u.dimensionless_unscaled  # θ ra is log, model is linear
         self.ra <<= R_units
 
         self.v2Tj <<= V2_units
@@ -919,6 +920,8 @@ class Model(lp.limepy):
         # fix a couple of conflicted attributes
         self.s2 = self._theta['s2']
         self.Nj = self.Mj / self.mj
+        # TODO not really sure what the limepy.ra corresponds to right now
+        # self.ra = 10**self._theta['ra']
 
         # ------------------------------------------------------------------
         # Assign units to model values

--- a/fitter/probabilities/probabilities.py
+++ b/fitter/probabilities/probabilities.py
@@ -542,7 +542,7 @@ def likelihood_number_density(model, ndensity, *,
     obs_err = ndensity['ΔΣ'][valid]
 
     # Now nuisance parameter (from θ, not the model velocity scale)
-    s2 = model._theta['s2']
+    s2 = model.theta['s2']
     yerr = np.sqrt(obs_err**2 + (s2 * obs_err.unit**2))
 
     model_r = model.r.to(obs_r.unit)

--- a/fitter/probabilities/probabilities.py
+++ b/fitter/probabilities/probabilities.py
@@ -541,8 +541,9 @@ def likelihood_number_density(model, ndensity, *,
     obs_Σ = ndensity['Σ'][valid]
     obs_err = ndensity['ΔΣ'][valid]
 
-    # Now nuisance parameter
-    yerr = np.sqrt(obs_err**2 + (model.s2 * obs_err.unit**2))
+    # Now nuisance parameter (from θ, not the model velocity scale)
+    s2 = model._theta['s2']
+    yerr = np.sqrt(obs_err**2 + (s2 * obs_err.unit**2))
 
     model_r = model.r.to(obs_r.unit)
     model_Σ = model.Sigmaj[mass_bin] / model.mj[mass_bin]


### PR DESCRIPTION
Reorganizes some aspects of how the `Model` class interacts with the parent `limepy` models and clears up some plotting labels, all in the effort to make better sense of the `ra` parameter.

Firstly, it was not being noted that the `ra` parameter is actually logged.
Secondly, the scaling done by `limepy` wasn't entirely being accounted for correctly.

Nothing here changes the actual fit outcomes or models, but does change how you interact with the `Model` class.