### PR TITLE
fix outdated references to `model.F` attribute

### DIFF
--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -1618,7 +1618,7 @@ class ModelVisualizer(_ClusterVisualizer):
         self.rh = model.rh
         self.ra = model.ra
         self.rt = model.rt
-        self.F = model.F
+        self.F = model.theta['F']
         self.s2 = model.theta['s2']
         self.d = model.d
 

--- a/fitter/probabilities/probabilities.py
+++ b/fitter/probabilities/probabilities.py
@@ -993,7 +993,7 @@ def likelihood_mass_func(model, mf, field, *, hyperparams=False):
 
         N_data[r_mask] = N[r_mask]
         N_model[r_mask] = N_spline(mbin_mean[r_mask])
-        err[r_mask] = model.F * ΔN[r_mask]
+        err[r_mask] = model.theta['F'] * ΔN[r_mask]
 
     return likelihood(N_data, N_model, err)
 


### PR DESCRIPTION
Should now point to `theta` attribute, not `F` directly, due to the changes in #104 

(this highlights a need unit tests, as this snuck through to main, but completely breaks the massfunc likelihoods)