### PR TITLE
allow low-mass MF exponent to be slightly negative

### DIFF
--- a/fitter/probabilities/priors.py
+++ b/fitter/probabilities/priors.py
@@ -658,8 +658,8 @@ DEFAULT_PRIORS = {
     'delta': ('uniform', [(0.3, 0.5)]),
     's2': ('uniform', [(0, 15)]),
     'F': ('uniform', [(1, 3)]),
-    'a1': ('uniform', [(0, 2.35)]),
-    'a2': ('uniform', [(0, 2.35), ('a1', np.inf)]),
+    'a1': ('uniform', [(-1, 2.35)]),
+    'a2': ('uniform', [(-1, 2.35), ('a1', np.inf)]),
     'a3': ('uniform', [(1.6, 4), ('a2', np.inf)]),
     'BHret': ('uniform', [(0, 100)]),
     'd': ('uniform', [(2, 8)])


### PR DESCRIPTION
No real reason we should be restricting the low-mass MF
slopes to be decreasing always, especially for depleted clusters.
This change simply reflects that as a default.
The value of -1 is arbitrary but can be changed if any clusters
begin to hit that as well.