### PR TITLE
Rewrite `cluster_component` (fixes #16).

### DIFF
--- a/fitter/probabilities/probabilities.py
+++ b/fitter/probabilities/probabilities.py
@@ -175,9 +175,12 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
                 )
 
         except ValueError as err:
-            # temporary fix for z2 interpolation error
-
-            mssg = "Pulsar `cluster_component` failed with error:"
+            # The cluster component shouldn't be crashing nearly as often now,
+            # should only happen when Paz fails to integrate to 1.0
+            mssg = f"""
+            Pulsar `cluster_component` failed with params: "
+            {model.theta=}, {R=}, {mass_bin=}, {DM=}, with error:
+            """
             logging.warning(mssg, exc_info=err)
 
             return np.NINF

--- a/fitter/probabilities/probabilities.py
+++ b/fitter/probabilities/probabilities.py
@@ -292,7 +292,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
 
     logprobs = np.log(probs)
 
-    # Should never occur anymore, but leave it here for now just in case
+    # Replace NaNs with -inf
     logprobs[np.isnan(logprobs)] = np.NINF
 
     return np.sum(logprobs)
@@ -481,9 +481,12 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
     # Multiply all the probabilities and return the total log probability.
     # ----------------------------------------------------------------------
 
-    # Catch any NaNs
-    probs[np.isnan(probs)] = np.NINF
-    return np.sum(np.log(probs))
+    logprobs = np.log(probs)
+
+    # Replace NaNs with -inf
+    logprobs[np.isnan(logprobs)] = np.NINF
+
+    return np.sum(logprobs)
 
 
 @_angular_units

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -125,7 +125,7 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
 
     # Now compute P(a_z|R)
 
-    nr = nz  # bit of experimenting
+    nr = nz
 
     # There are 2 possibilities depending on R:
     # (1) the maximum acceleration occurs within the cluster boundary, or
@@ -228,7 +228,7 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
             # get the index
             arg_zero = np.argmin(Paz_dist)
             # dont overflow the array
-            if 0 < arg_zero <len (Paz_dist)-1:
+            if 0 < arg_zero < len(Paz_dist)-1:
                 # interpolate between the two neighbouring points
                 Paz_dist[arg_zero] = (
                     Paz_dist[arg_zero - 1] + Paz_dist[arg_zero + 1]
@@ -336,9 +336,6 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
         Paz_dist /= 2
 
     # Change the acceleration domain to a Pdot / P domain
-    # TODO (Peter): Reminder here to double check with Nolan/Vincent that this
-    # final distribution should be normalized to 1.0, even after the conversion
-    # from az to Pdot/P.
     PdotP_domain = az_domain / c
     P_PdotP_dist = Paz_dist * c.value
 

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -249,16 +249,23 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
 
         else:
             # This is the case where our probability distribution doesn't
-            # integrate to one, just don't cut anything off, log the
-            # normalization and manually normalize it.
+            # integrate to one.
+
+            # If the area is way less than 1, we should just throw an exception
+            if norm < 0.9:
+                logging.error(
+                    "Probability distribution failed to integrate "
+                    f"to 1.0, area: {norm:.6f}, too small to continue."
+                )
+                raise ValueError("Paz failed to integrate to 1.0, too small to"
+                                f"continue. Area: {norm:.6f}")
+
+            # If the area is close to 1, we should just log a warning and
+            # manually normalize it
             logging.warning(
                 "Probability distribution failed to integrate "
                 f"to 1.0, area: {norm:.6f}"
             )
-
-            # TODO: in the cases where this isn't close to 1, there's been
-            # a serious failure and we should be returning -inf, not just
-            # logging and continuing
 
             # Manual normalization
             Paz_dist /= norm
@@ -299,6 +306,16 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
             # This is the case where our probability distribution doesn't
             # integrate to one, just don't cut anything off, log the
             # normalization and manually normalize it.
+
+            # If the area is way less than 1, we should just throw an exception
+            if norm < 0.9:
+                logging.error(
+                    "Probability distribution failed to integrate "
+                    f"to 1.0, area: {norm:.6f}, too small to continue."
+                )
+                raise ValueError("Paz failed to integrate to 1.0, too small to"
+                                f"continue. Area: {norm:.6f}")
+
             logging.warning(
                 "Probability distribution failed to integrate "
                 f"to 1.0, area: {norm:.6f}"

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -344,15 +344,16 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
     # final distribution should be normalized to 1.0, even after the conversion
     # from az to Pdot/P.
     PdotP_domain = az_domain / c
+    P_PdotP_dist = Paz_dist * c.value
 
     # put the signs back in for the DM method
     if DM is not None:
         PdotP_domain *= az_signs
 
     # Trim the peaks from numerical instability around azmax
-    Paz_dist = trim_peaks(PdotP_domain * c, Paz_dist)
+    Paz_dist = trim_peaks(PdotP_domain, P_PdotP_dist)
 
-    return PdotP_domain, Paz_dist
+    return PdotP_domain, P_PdotP_dist
 
 
 def galactic_component(lat, lon, D):

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -7,7 +7,6 @@ import astropy.units as u
 from astropy.constants import c
 
 import pathlib
-from importlib import resources
 import logging
 
 
@@ -114,9 +113,6 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
     # Location of the maximum acceleration along this los
     zmax = az_der.roots()
 
-    # Acceleration at zt
-    azt = az[-1]
-
     # Setup spline for the density, depending on mass bin
     if mass_bin == 0 and model.nmbin == 1:
         rho = model.rho
@@ -129,7 +125,7 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
 
     # Now compute P(a_z|R)
 
-    nr, k = nz, 3  # bit of experimenting
+    nr = nz  # bit of experimenting
 
     # Value of the maximum acceleration, at the chosen root
     azmax = az_spl(zmax[0])

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -253,10 +253,6 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
 
             # If the area is way less than 1, we should just throw an exception
             if norm < 0.9:
-                logging.error(
-                    "Probability distribution failed to integrate "
-                    f"to 1.0, area: {norm:.6f}, too small to continue."
-                )
                 raise ValueError("Paz failed to integrate to 1.0, too small to"
                                 f"continue. Area: {norm:.6f}")
 

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -219,8 +219,15 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
         # which I expect might do bad things to convolution, so I'm just
         # going to interpolate it, this is a bit hacky but I don't see a cleaner
         # way to do it, and this gives a nice smooth distribution
-        arg_zero = np.argmin(Paz_dist)
-        Paz_dist[arg_zero] = (Paz_dist[arg_zero+1] + Paz_dist[arg_zero-1]) / 2
+        if np.any(Paz_dist == 0.0):
+            # get the index
+            arg_zero = np.argmin(Paz_dist)
+            # dont overflow the array
+            if 0 < arg_zero <len (Paz_dist)-1:
+                # interpolate between the two neighbouring points
+                Paz_dist[arg_zero] = (
+                    Paz_dist[arg_zero - 1] + Paz_dist[arg_zero + 1]
+                ) / 2.0
 
     # Ensure Paz is normalized (slightly different for density vs DM methods)
 

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -318,7 +318,7 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
             # If the area is way less than 1, we should just throw an exception
             if norm < 0.9:
                 raise ValueError("Paz failed to integrate to 1.0, too small to"
-                                f"continue. Area: {norm:.6f}")
+                                f" continue. Area: {norm:.6f}")
 
             logging.warning(
                 "Probability distribution failed to integrate "

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -268,13 +268,6 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
                 raise ValueError("Paz failed to integrate to 1.0, too small to"
                                 f"continue. Area: {norm:.6f}")
 
-            # If the area is close to 1, we should just log a warning and
-            # manually normalize it
-            logging.warning(
-                "Probability distribution failed to integrate "
-                f"to 1.0, area: {norm:.6f}"
-            )
-
             # Manual normalization
             Paz_dist /= norm
 
@@ -319,11 +312,6 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
             if norm < 0.9:
                 raise ValueError("Paz failed to integrate to 1.0, too small to"
                                 f" continue. Area: {norm:.6f}")
-
-            logging.warning(
-                "Probability distribution failed to integrate "
-                f"to 1.0, area: {norm:.6f}"
-            )
 
             # Manual normalization
             Paz_dist /= norm

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -305,10 +305,6 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
 
             # If the area is way less than 1, we should just throw an exception
             if norm < 0.9:
-                logging.error(
-                    "Probability distribution failed to integrate "
-                    f"to 1.0, area: {norm:.6f}, too small to continue."
-                )
                 raise ValueError("Paz failed to integrate to 1.0, too small to"
                                 f"continue. Area: {norm:.6f}")
 

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -127,8 +127,13 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
 
     nr = nz  # bit of experimenting
 
-    # Value of the maximum acceleration, at the chosen root
-    azmax = az_spl(zmax[0])
+    # There are 2 possibilities depending on R:
+    # (1) the maximum acceleration occurs within the cluster boundary, or
+    # (2) max(a_z) = a_z,t (this happens when R ~ r_t)
+    if len(zmax) > 0:
+        azmax = az_spl(zmax[0])
+    else:
+        azmax = az_spl(z[-1])
 
     # Old version here for future reference
     # increment density by 2 order of magnitude smaller than azmax

--- a/fitter/probabilities/pulsars.py
+++ b/fitter/probabilities/pulsars.py
@@ -344,6 +344,9 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *, 
         Paz_dist /= 2
 
     # Change the acceleration domain to a Pdot / P domain
+    # TODO (Peter): Reminder here to double check with Nolan/Vincent that this
+    # final distribution should be normalized to 1.0, even after the conversion
+    # from az to Pdot/P.
     PdotP_domain = az_domain / c
 
     # put the signs back in for the DM method

--- a/fitter/util/probabilities.py
+++ b/fitter/util/probabilities.py
@@ -1,5 +1,5 @@
 import numpy as np
-import scipy as sp
+from .units import QuantitySpline
 
 __all__ = ['gaussian', 'RV_transform', 'gaussian_likelihood',
            'hyperparam_likelihood', 'hyperparam_effective', 'div_error',
@@ -24,7 +24,7 @@ def RV_transform(domain, f_X, h, h_prime):
 
 def find_intersections(y, x, value):
     '''Find the intersections of a function with a given value.'''
-    spl = sp.interpolate.InterpolatedUnivariateSpline(x, y - value, k=3, ext=2)
+    spl = QuantitySpline(x, y - value, k=3, ext=2)
     return spl.roots()
 
 # --------------------------------------------------------------------------

--- a/fitter/util/probabilities.py
+++ b/fitter/util/probabilities.py
@@ -1,8 +1,9 @@
 import numpy as np
+import scipy as sp
 
 __all__ = ['gaussian', 'RV_transform', 'gaussian_likelihood',
            'hyperparam_likelihood', 'hyperparam_effective', 'div_error',
-           'trim_peaks']
+           'trim_peaks', 'find_intersections']
 
 # --------------------------------------------------------------------------
 # Generic Distribution Helpers
@@ -21,6 +22,10 @@ def RV_transform(domain, f_X, h, h_prime):
     f_Y = f_X(h(domain)) * np.abs(h_prime(domain))
     return np.nan_to_num(f_Y)
 
+def find_intersections(y, x, value):
+    '''Find the intersections of a function with a given value.'''
+    spl = sp.interpolate.InterpolatedUnivariateSpline(x, y - value, k=3, ext=2)
+    return spl.roots()
 
 # --------------------------------------------------------------------------
 # Gaussian Likelihood


### PR DESCRIPTION
Starting the pull request for this now, needs a lot of clean up and the DM stuff is broken right now but the regular method is at least working. 

Quick summary is that in #16, we realized that for some models, the az vs z profile can actually have multiple peaks. The correct behaviour is to calculate the probability using all of the possible z values for a given value of az. This rewrites the core logic of `cluster_component` to use a root-finding approach instead of trying to treat the problem like an interpolation problem. This means that we can handle multiple peaks without issues and we should stop seeing so many crashes from the pulsar likelihood.