### PR TITLE
Add `restrict_to` keyword to all sampling functions

### DIFF
--- a/bin/GCfitter
+++ b/bin/GCfitter
@@ -103,6 +103,10 @@ if __name__ == '__main__':
     parallel_group.add_argument("--mpi", action="store_true",
                                 help="Run with MPI rather than multiprocessing")
 
+    shared_parser.add_argument('--restrict-to', default=None,
+                               choices={None, 'local', 'core'},
+                               help='Optionally restrict datafiles used to '
+                                    '"core" or "local" cluster files')
     shared_parser.add_argument('--savedir', default=default_dir,
                                help='location of saved sampling runs')
     shared_parser.add_argument('-i', '--initials',

--- a/fitter/analysis/models.py
+++ b/fitter/analysis/models.py
@@ -2117,7 +2117,6 @@ class CIModelVisualizer(_ClusterVisualizer):
         # very large rt. I'm not really sure yet how that might affect the CIs
         # or plots
 
-        # TODO https://github.com/nmdickson/GCfit/issues/100
         huge_model = Model(chain[np.argmax(chain[:, 4])], viz.obs)
 
         viz.r = np.r_[0, np.geomspace(1e-5, huge_model.rt.value, 99)] << u.pc
@@ -2714,7 +2713,6 @@ class CIModelVisualizer(_ClusterVisualizer):
         ''' load the CI from a file which was `save`d, to avoid rerunning models
         validate: check while loading that all datasets are there, error if not
         '''
-        # TODO load should accept an optional observations like all others
 
         with h5py.File(filename, 'r') as file:
 
@@ -2726,7 +2724,9 @@ class CIModelVisualizer(_ClusterVisualizer):
 
             # init class
             if (obs := observations) is None:
-                obs = Observations(modelgrp['metadata'].attrs['cluster'])
+                restrict = modelgrp['metadata'].attrs.get('restrict_to', None)
+                obs = Observations(modelgrp['metadata'].attrs['cluster'],
+                                   restrict_to=restrict)
 
             viz = cls(obs)
 

--- a/fitter/core/main.py
+++ b/fitter/core/main.py
@@ -1,4 +1,5 @@
 from .data import Observations
+from ..util.data import GCFIT_DIR
 from ..probabilities import posterior, priors
 from ..util.probabilities import plateau_weight_function
 
@@ -291,7 +292,7 @@ class NestedSamplingOutput(Output):
 def MCMC_fit(cluster, Niters, Nwalkers, Ncpu=2, *,
              mpi=False, initials=None, param_priors=None, moves=None,
              fixed_params=None, excluded_likelihoods=None, hyperparams=False,
-             cont_run=False, savedir=_here, backup=False,
+             cont_run=False, savedir=_here, backup=False, restrict_to=None,
              verbose=False, progress=False):
     '''Main MCMC fitting pipeline
 
@@ -406,7 +407,7 @@ def MCMC_fit(cluster, Niters, Nwalkers, Ncpu=2, *,
 
     logging.info(f"Loading {cluster} data")
 
-    observations = Observations(cluster)
+    observations = Observations(cluster, restrict_to=restrict_to)
 
     logging.debug(f"Observation datasets: {observations}")
 
@@ -501,7 +502,9 @@ def MCMC_fit(cluster, Niters, Nwalkers, Ncpu=2, *,
 
         backend.store_metadata('cluster', cluster)
 
-        backend.store_metadata('GCFIT_DIR', os.getenv('GCFIT_DIR', 'CORE'))
+        backend.store_metadata('restrict_to', restrict_to)
+        backend.store_metadata('GCFIT_DIR',
+                               'CORE' if restrict_to == 'core' else GCFIT_DIR)
 
         backend.store_metadata('mpi', mpi)
         backend.store_metadata('Ncpu', Ncpu)
@@ -614,7 +617,7 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
                pfrac=1.0, maxfrac=0.8, eff_samples=5000,
                Ncpu=2, mpi=False, initials=None, param_priors=None,
                fixed_params=None, excluded_likelihoods=None, hyperparams=False,
-               savedir=_here, verbose=False):
+               savedir=_here, restrict_to=None, verbose=False):
     '''Main nested sampling fitting pipeline
 
     Execute the full nested sampling cluster fitting algorithm.
@@ -750,7 +753,7 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
 
     logging.info(f"Loading {cluster} data")
 
-    observations = Observations(cluster)
+    observations = Observations(cluster, restrict_to=restrict_to)
 
     logging.debug(f"Observation datasets: {observations}")
 
@@ -836,7 +839,9 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
 
         backend.store_metadata('cluster', cluster)
 
-        backend.store_metadata('GCFIT_DIR', os.getenv('GCFIT_DIR', 'CORE'))
+        backend.store_metadata('restrict_to', restrict_to)
+        backend.store_metadata('GCFIT_DIR',
+                               'CORE' if restrict_to == 'core' else GCFIT_DIR)
 
         backend.store_metadata('mpi', mpi)
         backend.store_metadata('Ncpu', Ncpu)


### PR DESCRIPTION
In order to solve a handful of problems (including closing #155) this propagates the `restrict_to` keyword (which determines where the Observations datafile is taken from) to `GCfitter` and the various sampler functions. This keyword is also stored in the run metadata and can be used to recreate the state later, in tandem with the "GCFIT_DIR" metadata