### PR TITLE
fix typo in nested sampler too (missed by #161)

### DIFF
--- a/fitter/core/main.py
+++ b/fitter/core/main.py
@@ -840,8 +840,8 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
         backend.store_metadata('cluster', cluster)
 
         backend.store_metadata('restrict_to', restrict_to)
-        backend.store_metadata('GCFIT_DIR',
-                               'CORE' if restrict_to == 'core' else GCFIT_DIR)
+        backend.store_metadata('GCFIT_DIR', 'CORE' if restrict_to == 'core'
+                                            else str(GCFIT_DIR))
 
         backend.store_metadata('mpi', mpi)
         backend.store_metadata('Ncpu', Ncpu)


### PR DESCRIPTION
Fixed this type error in MCMC fitting with last PR, but forgot to also fix the error in the nested sampler.
Again highlights the need to resolve #99.