### PR TITLE
Hotfix/script defaults

### DIFF
--- a/gcfit/core/main.py
+++ b/gcfit/core/main.py
@@ -68,7 +68,13 @@ class Output:
                 if v.dtype.kind == 'U':
                     v = v.astype('S')
 
-                dset.attrs[f'{k}{type_postfix}'] = v
+                try:
+                    dset.attrs[f'{k}{type_postfix}'] = v
+
+                except TypeError as err:
+                    mssg = f'Could not store metadata {key}:{k}={v} ({err})'
+                    logging.debug(mssg)
+                    continue
 
         elif isinstance(value, abc.Collection) \
                 and not isinstance(value, _str_types):
@@ -82,11 +88,23 @@ class Output:
                 if v.dtype.kind == 'U':
                     v = v.astype('S')
 
-                dset.attrs[f'{i}{type_postfix}'] = v
+                try:
+                    dset.attrs[f'{i}{type_postfix}'] = v
+
+                except TypeError as err:
+                    mssg = f'Could not store metadata {key}[{i}]={v} ({err})'
+                    logging.debug(mssg)
+                    continue
 
         else:
 
-            meta_grp.attrs[f'{key}{type_postfix}'] = value
+            try:
+                meta_grp.attrs[f'{key}{type_postfix}'] = value
+
+            except TypeError as err:
+                mssg = f'Could not store metadata {key}={value} ({err})'
+                logging.debug(mssg)
+                pass
 
         if not file:
             hdf.close()

--- a/gcfit/scripts/GCfitter.py
+++ b/gcfit/scripts/GCfitter.py
@@ -95,8 +95,6 @@ def main():
     # Common arguments to all samplers
     # ----------------------------------------------------------------------
 
-    # TODO make all defaults here match defaults in main functions
-
     shared_parser = argparse.ArgumentParser(add_help=False)
 
     parallel_group = shared_parser.add_mutually_exclusive_group()
@@ -149,9 +147,9 @@ def main():
 
     parser_MCMC = subparsers.add_parser('MCMC', parents=[shared_parser])
 
-    parser_MCMC.add_argument('-N', '--Niters', default=2000, type=pos_int,
+    parser_MCMC.add_argument('-N', '--Niters', required=True, type=pos_int,
                              help='Number of sampling iterations')
-    parser_MCMC.add_argument('--Nwalkers', default=150, type=pos_int,
+    parser_MCMC.add_argument('--Nwalkers', required=True, type=pos_int,
                              help='Number of walkers for MCMC sampler')
 
     parser_MCMC.add_argument('--moves', type=str.lower, nargs='*',
@@ -180,8 +178,9 @@ def main():
 
     parser_nest.add_argument('--pfrac', default=1.0, type=float,
                              help='Posterior weighting fraction f_p')
-    parser_nest.add_argument('--dlogz', default=0.25, type=float,
-                             help='Δln(Z) tolerance initial stopping condition')
+    parser_nest.add_argument('--dlogz', default=0.01, type=float,
+                             help='Δln(Z) tolerance initial stopping condition.'
+                                  ' See dynesty for info on defaults')
     parser_nest.add_argument('--maxfrac', default=0.8, type=float,
                              help='The fractional threshold, relative to the '
                                   'peak weight, used to determine likelihood '
@@ -195,11 +194,12 @@ def main():
                                   'are met')
     parser_nest.add_argument('--init-maxiter', default=None, type=pos_int,
                              help='Maximum number of iterations allowed in the '
-                                  'baseline run')
-    parser_nest.add_argument('--N-per-batch', default=100, type=pos_int,
+                                  'baseline run. Default is no limit')
+    parser_nest.add_argument('--N-per-batch', default=None, type=pos_int,
                              dest='Nlive_per_batch',
-                             help='Number of live points to add each batch')
-    parser_nest.add_argument('--bound-type', default='balls',
+                             help='Number of live points to add each batch. '
+                                  'See dynesty for info on defaults')
+    parser_nest.add_argument('--bound-type', default='multi',
                              choices=bound_choices,
                              help='Method used to bound sampling on the prior')
     parser_nest.add_argument('--sample-type', default='auto',


### PR DESCRIPTION
Bring some of the fitting script argument defaults into agreement with the defaults in the actual core python fitting functions.
Mostly needed to help avoid some confusion when comparing runs, but in reality you should be always looking at the sampler output "metadata" to determine which arguments were used anyways.

This sets a few defaults that are maybe not the most efficient (i.e. `dlogz`) but are required to be in line with the core defaults, which are implicitly taken from `dynesty`. When in doubt, never rely on the defaults.