### PR TITLE
Hotfix/mass fraction units

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -1898,8 +1898,8 @@ class ModelVisualizer(_ClusterVisualizer):
         self.star_bin = model.nms - 1
         self.mj = model.mj
 
-        self.f_rem = np.sum(model.Mj[model._remnant_bins]) / model.M
-        self.f_BH = np.sum(model.BH_Mj) / model.M
+        self.f_rem = model.f_rem
+        self.f_BH = model.f_BH
 
         self.LOS = np.sqrt(self.model.v2pj)[:, np.newaxis, :]
         self.pm_T = np.sqrt(model.v2Tj)[:, np.newaxis, :]
@@ -2418,8 +2418,8 @@ class CIModelVisualizer(_ClusterVisualizer):
 
             frac_M_MS[slc], frac_M_rem[slc] = viz._init_mass_frac(model)
 
-            f_rem[model_ind] = np.sum(model.Mj[model._remnant_bins]) / model.M
-            f_BH[model_ind] = np.sum(model.BH_Mj) / model.M
+            f_rem[model_ind] = model.f_rem
+            f_BH[model_ind] = model.f_BH
 
             # Black holes
 

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -2475,6 +2475,8 @@ class RunCollection(_RunAnalysis):
             'RA': r'\deg',
             'DEC': r'\deg',
             'BH_mass': r'M_\odot',
+            'f_rem': r'\%',
+            'f_BH': r'\%',
             'r0': r'\mathrm{pc}',
             'rt': r'\mathrm{pc}',
             'rv': r'\mathrm{pc}',

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1194,6 +1194,16 @@ class Model(lp.limepy):
         self.NS_rhoj = self.rhoj[self._remnant_bins][self._NS_bins]
         self.NS_Sigmaj = self.Sigmaj[self._remnant_bins][self._NS_bins]
 
+        # ------------------------------------------------------------------
+        # Get remnant fractions
+        # ------------------------------------------------------------------
+
+        self.f_rem = (np.sum(self.Mj[self._remnant_bins]) / self.M).to(u.pct)
+
+        self.f_BH = (np.sum(self.BH_Mj) / self.M).to(u.pct)
+        self.f_WD = (np.sum(self.WD_Mj) / self.M).to(u.pct)
+        self.f_NS = (np.sum(self.NS_Mj) / self.M).to(u.pct)
+
     # ----------------------------------------------------------------------
     # Alternative generators
     # ----------------------------------------------------------------------


### PR DESCRIPTION
Moves the remnant mass fractions to be quantities on the base `Model`, not only available through `analysis`, and changes their units to percentages as a default.