### PR TITLE
Feature/parameter run masking

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -2311,8 +2311,8 @@ class CIModelVisualizer(_ClusterVisualizer):
         frac_M_MS = np.full((1, N, Nr), np.nan) << u.dimensionless_unscaled
         frac_M_rem = frac_M_MS.copy()
 
-        f_rem = np.full(N, np.nan) << u.dimensionless_unscaled
-        f_BH = np.full(N, np.nan) << u.dimensionless_unscaled
+        f_rem = np.full(N, np.nan) << u.pct
+        f_BH = np.full(N, np.nan) << u.pct
 
         # number density
 

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -252,6 +252,10 @@ class _SingleRunAnalysis(_RunAnalysis):
 
             _, ch = self._get_chains(include_fixed=False, apply_mask=False)
 
+            # flatten chain if necessary (to work with MCMC, mask must be flat)
+            if ch.ndim > 2:
+                ch = ch.reshape((-1, ch.shape[-1]))
+
             if value.ndim > 1 or value.shape[0] != ch.shape[0]:
                 mssg = (f'Invalid mask shape {value.shape}; '
                         f'must have shape {ch[:, 0].shape}')
@@ -277,6 +281,9 @@ class _SingleRunAnalysis(_RunAnalysis):
             raise ValueError(mssg)
 
         data = self._get_chains(apply_mask=False)[1][..., labels.index(param)]
+
+        if data.ndim > 1:
+            data = data.reshape((-1, data.shape[-1]))
 
         mask = (data < lower_lim) | (data > upper_lim)
 

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -242,6 +242,9 @@ class _SingleRunAnalysis(_RunAnalysis):
     def mask(self):
         return self._mask
 
+    def reset_mask(self):
+        self._mask = None
+
     @mask.setter
     def mask(self, value):
 
@@ -261,6 +264,11 @@ class _SingleRunAnalysis(_RunAnalysis):
             self.results = self._get_results()
 
     def slice_on_param(self, param, lower_lim, upper_lim):
+        '''set `self.mask` based on a parameter value
+
+        already present masks will be combined, if that's not desired, you
+        should `self.reset_mask()` first.
+        '''
 
         labels = self._get_labels()
 
@@ -270,8 +278,12 @@ class _SingleRunAnalysis(_RunAnalysis):
 
         data = self._get_chains(apply_mask=False)[1][..., labels.index(param)]
 
-        # TODO how should updating masks work?
-        self.mask = (data < lower_lim) | (data > upper_lim)
+        mask = (data < lower_lim) | (data > upper_lim)
+
+        if self.mask is None:
+            self.mask = mask
+        else:
+            self.mask |= mask
 
     def __str__(self):
         try:

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -247,11 +247,7 @@ class _SingleRunAnalysis(_RunAnalysis):
 
         if value is not None:
 
-            # _, ch = self._get_chains(include_fixed=False)
-
-            with self._openfile() as file:
-                # TODO will fail for MCMC
-                ch = file[self._gname]['samples'][:]
+            _, ch = self._get_chains(include_fixed=False, apply_mask=False)
 
             if value.ndim > 1 or value.shape[0] != ch.shape[0]:
                 mssg = (f'Invalid mask shape {value.shape}; '
@@ -272,7 +268,7 @@ class _SingleRunAnalysis(_RunAnalysis):
             mssg = f'Invalid param "{param}". Must be one of {labels}'
             raise ValueError(mssg)
 
-        data = self._get_chains()[1][..., labels.index(param)]
+        data = self._get_chains(apply_mask=False)[1][..., labels.index(param)]
 
         # TODO how should updating masks work?
         self.mask = (data < lower_lim) | (data > upper_lim)

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -84,6 +84,19 @@ class _RunAnalysis:
         if self.results is not None:
             self.results = self._get_results()
 
+    def slice_on_param(self, param, lower_lim, upper_lim):
+
+        labels = self._get_labels()
+
+        if param not in labels:
+            mssg = f'Invalid param "{param}". Must be one of {labels}'
+            raise ValueError(mssg)
+
+        data = self._get_chains()[1][..., labels.index(param)]
+
+        # TODO how should updating masks work?
+        self.mask = (data < lower_lim) | (data > upper_lim)
+
     def __str__(self):
         try:
             return f'{self._filename} - Run Results'

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -1034,7 +1034,7 @@ class NestedRun(_SingleRunAnalysis):
     # Helpers
     # ----------------------------------------------------------------------
 
-    def _get_results(self, finite_only=False):
+    def _get_results(self, finite_only=False, *, apply_mask=True):
         '''return a dynesty-style `Results` class'''
         from dynesty.results import Results
 
@@ -1057,7 +1057,7 @@ class NestedRun(_SingleRunAnalysis):
                 if d.shape and (d.shape[0] == Niter):
                     d = np.array(d)[inds]
 
-                    if self.mask is not None:
+                    if apply_mask and self.mask is not None:
                         d = d[self.mask]
 
                 else:
@@ -1174,14 +1174,14 @@ class NestedRun(_SingleRunAnalysis):
         return labels
 
     # TODO some ways of handling and plotting initial_batch only clusters
-    def _get_chains(self, include_fixed=True):
+    def _get_chains(self, include_fixed=True, *, apply_mask=True):
         '''for nested sampling results (current Batch)'''
 
         with self._openfile() as file:
 
             chain = file[self._gname]['samples'][:]
 
-            if self.mask is not None:
+            if apply_mask and self.mask is not None:
                 chain = chain[self.mask, :]
 
             labels = list(self.obs.initials)
@@ -1202,7 +1202,8 @@ class NestedRun(_SingleRunAnalysis):
 
         return labels, chain
 
-    def _get_equal_weight_chains(self, include_fixed=True, add_errors=False):
+    def _get_equal_weight_chains(self, include_fixed=True, add_errors=False, *,
+                                 apply_mask=True):
         from dynesty.utils import resample_equal
 
         with self._openfile() as file:
@@ -1210,7 +1211,7 @@ class NestedRun(_SingleRunAnalysis):
             if add_errors is False:
                 chain = file[self._gname]['samples'][:]
 
-                if self.mask is not None:
+                if apply_mask and self.mask is not None:
                     chain = chain[self.mask, :]
 
                 eq_chain = resample_equal(chain, self.weights)

--- a/gcfit/scripts/generate_model_CI.py
+++ b/gcfit/scripts/generate_model_CI.py
@@ -42,9 +42,19 @@ def main():
     parser.add_argument('--overwrite', action='store_true',
                         help='Overwrite saved CIs if already exist. Be careful')
 
+    parser.add_argument('--mask', nargs=3, default=False,
+                        metavar=('PARAM', 'LOWER_LIM', 'UPPER_LIM'),
+                        help='Apply a mask to each run based on a param')
+
+    parser.add_argument('-o', '--output', nargs='+', default=None,
+                        help='Alternative files only for saving CI outputs')
+
     parser.add_argument('--debug', action='store_true')
 
     args = parser.parse_args()
+
+    if args.output is None:
+        args.output = args.filenames
 
     if args.debug:
         now = datetime.datetime.now()
@@ -64,6 +74,13 @@ def main():
 
     rc = analysis.RunCollection.from_files(args.filenames)
 
+    if args.mask:
+        mask_prm = args.mask[0]
+        mask_dnlim, mask_uplim = float(args.mask[1]), float(args.mask[2])
+
+        for run in rc:
+            run.slice_on_param(mask_prm, mask_dnlim, mask_uplim)
+
     mc = rc.get_CImodels(N=args.N, Nprocesses=args.Ncpu, load=False)
 
-    mc.save(args.filenames, overwrite=args.overwrite)
+    mc.save(args.output, overwrite=args.overwrite)


### PR DESCRIPTION
Adds the ability to apply a "mask" to a `MCMCRun` or `NestedRun`, which will mask some of the values in a given run chain, and thus change what is plotted.

This was designed to handle things like bimodal distributions, which of course do not show up correctly in plots based on median values and quantiles (i.e. `plot_relation`), by allowing cleanly separable peaks to be masked out.
This really only happened once for NGC6723, and I don't suspect this is a very necessary feature otherwise, so it is not very fleshed out (for example, currently does not work perfectly for things like `plot_params`). It might be improved in the future, say to replace the `reduce` logic in MCMC runs, or it might just be removed.