### PR TITLE
Hotfix/string variables

### DIFF
--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -92,7 +92,8 @@ class Variable(u.Quantity):
         if not is_str:
             quant = super().__new__(cls, value, unit, *args, **kwargs)
         else:
-            quant = np.asarray(value, *args, **kwargs).view(cls)
+            # Coerce string to dtype "U" here, hdf5 cannot store that natively
+            quant = np.asarray(value, dtype='U', *args, **kwargs).view(cls)
 
         # Store the metadata
         if isinstance(mdata, dict):

--- a/gcfit/util/data.py
+++ b/gcfit/util/data.py
@@ -1475,6 +1475,10 @@ class Dataset:
             for colname in keys:
                 data = df[colname].to_numpy()
 
+                if data.dtype.kind == 'O' and isinstance(data[0], (str, bytes)):
+                    # Need to use bytes array for strings, hdf5 can't handle "U"
+                    data = data.astype('S')
+
                 varname = names.get(colname, colname)
 
                 # TODO still don't know how best to get units from the data file


### PR DESCRIPTION
Fix a couple small bugs related to the fact that HDF5 files [cannot store the typical string dtype, but only `bytes` arrays](https://docs.h5py.org/en/stable/strings.html). This fixes the issue while creating new `ClusterFile`s with string variables read from something like a CSV file.