### PR TITLE
add some better nested sampler default args

### DIFF
--- a/gcfit/core/main.py
+++ b/gcfit/core/main.py
@@ -683,11 +683,13 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
 
     initial_kwargs : dict, optional
         kwargs to be passed to the `dynesty.DynamicNestedSampler.sample_initial`
-        initial baseline sampling function. See `dynesty` for more.
+        initial baseline sampling function. Defaults include `dlogz` of 0.25
+        and `nlive` of 100. See `dynesty` for more info and all other defaults.
 
     batch_kwargs : dict, optional
         kwargs to be passed to the `dynesty.DynamicNestedSampler.sample_batch`
-        batch sampling function. See `dynesty` for more.
+        batch sampling function. Defaults include `nlive_new` of 100.
+        See `dynesty` for more info and all other defaults.
 
     pfrac : float, optional
         Fractional weight of the posterior (versus evidence) for stop function.
@@ -767,6 +769,10 @@ def nested_fit(cluster, *, bound_type='multi', sample_type='auto',
 
     if batch_kwargs is None:
         batch_kwargs = {}
+
+    # Apply some better default sampler arguments
+    initial_kwargs = {'nlive': 100, 'dlogz': 0.25} | initial_kwargs
+    batch_kwargs = {'nlive_new': 100} | batch_kwargs
 
     savedir = pathlib.Path(savedir)
     if not savedir.is_dir():

--- a/gcfit/scripts/GCfitter.py
+++ b/gcfit/scripts/GCfitter.py
@@ -178,9 +178,8 @@ def main():
 
     parser_nest.add_argument('--pfrac', default=1.0, type=float,
                              help='Posterior weighting fraction f_p')
-    parser_nest.add_argument('--dlogz', default=0.01, type=float,
-                             help='Δln(Z) tolerance initial stopping condition.'
-                                  ' See dynesty for info on defaults')
+    parser_nest.add_argument('--dlogz', default=0.25, type=float,
+                             help='Δln(Z) tolerance initial stopping condition')
     parser_nest.add_argument('--maxfrac', default=0.8, type=float,
                              help='The fractional threshold, relative to the '
                                   'peak weight, used to determine likelihood '
@@ -195,7 +194,7 @@ def main():
     parser_nest.add_argument('--init-maxiter', default=None, type=pos_int,
                              help='Maximum number of iterations allowed in the '
                                   'baseline run. Default is no limit')
-    parser_nest.add_argument('--N-per-batch', default=None, type=pos_int,
+    parser_nest.add_argument('--N-per-batch', default=100, type=pos_int,
                              dest='Nlive_per_batch',
                              help='Number of live points to add each batch. '
                                   'See dynesty for info on defaults')


### PR DESCRIPTION
Reverts a couple of the changes made to the defaults in the `GCfitter` script by #172 to much better values (i.e. values that even remotely work) and extends these defaults to the function as well.
This keeps the sharing of defaults between the two that was the motivation behind #172, while keeping the original values that are actually used. As long as how the defaults differ from the base sampler defaults (in dynesty) are documented, then it's okay.