### PR TITLE
Hotfix/mf random likelihood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ devnotes*
 /dist
 /results
 *ipynb_checkpoints*
+/profiling
 
 # Core latex/pdflatex auxiliary files:
 *.aux

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -353,6 +353,7 @@ class Observations:
     '''
 
     _valid_likelihoods = None
+    _MF_M_samples = 50_000
 
     def __repr__(self):
         return f'Observations(cluster="{self.cluster}")'
@@ -656,12 +657,19 @@ class Observations:
 
                 func = probabilities.likelihood_mass_func
 
-                # Field
+                # Field slices
                 cen = (self.mdata['RA'], self.mdata['DEC'])
 
                 field = util.mass.Field.from_dataset(self[key], cen)
 
-                comps.append((key, func, field))
+                rbins = np.c_[self[key]['r1'], self[key]['r2']]
+
+                fld_slices = []
+                for rind, (r_in, r_out) in enumerate(np.unique(rbins, axis=0)):
+                    field_slice = field.slice_radially(r_in, r_out)
+                    field_slice.MC_sample(M=self._MF_M_samples)
+
+                comps.append((key, func, fld_slices))
 
         return comps
 
@@ -1079,7 +1087,7 @@ class Model(lp.limepy):
         # Get mass function
         # ------------------------------------------------------------------
 
-        self._mf = EvolvedMF(
+        self._mf_kwargs = dict(
             m_breaks=m_breaks.value,
             a_slopes=[-a1, -a2, -a3],
             nbins=nbins,
@@ -1094,6 +1102,8 @@ class Model(lp.limepy):
             natal_kicks=natal_kicks,
             vesc=vesc.value
         )
+
+        self._mf = EvolvedMF(**self._mf_kwargs)
 
         mj, Mj = self._mf.m, self._mf.M
 

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -668,6 +668,7 @@ class Observations:
                 for rind, (r_in, r_out) in enumerate(np.unique(rbins, axis=0)):
                     field_slice = field.slice_radially(r_in, r_out)
                     field_slice.MC_sample(M=self._MF_M_samples)
+                    fld_slices.append(field_slice)
 
                 comps.append((key, func, fld_slices))
 

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -899,7 +899,7 @@ def likelihood_LOS(model, vlos, *, mass_bin=None, hyperparams=False):
 
 
 @_angular_units
-def likelihood_mass_func(model, mf, field, *, hyperparams=False):
+def likelihood_mass_func(model, mf, fields, *, hyperparams=False):
     r'''Compute the log likelihood of the cluster's PDMF
 
     Computes the log likelihood component of a cluster's present day mass
@@ -947,9 +947,6 @@ def likelihood_mass_func(model, mf, field, *, hyperparams=False):
         Monte Carlo integration method used to integrate the surface density
         profile
     '''
-    # TODO same as numdens, the units are ignored cause 1/pc^2 != 1/arcmin^2
-
-    M = 1000
 
     if hyperparams:
         likelihood = util.hyperparam_likelihood
@@ -989,16 +986,14 @@ def likelihood_mass_func(model, mf, field, *, hyperparams=False):
     N_model = np.empty_like(N)
     err = np.empty_like(N)
 
-    for r_in, r_out in np.unique(rbins, axis=0):
+    for field_slice, (r_in, r_out) in zip(fields, np.unique(rbins, axis=0)):
         r_mask = (mf['r1'] == r_in) & (mf['r2'] == r_out)
-
-        field_slice = field.slice_radially(r_in, r_out)
 
         # --------------------------------------------------------------
         # Sample this slice of the field M times, and integrate to get N
         # --------------------------------------------------------------
 
-        sample_radii = field_slice.MC_sample(M).to(u.pc)
+        sample_radii = field_slice._prev_sample.to(u.pc)
 
         binned_N_model = np.empty(model.nms) << N_data.unit
         for j in range(model.nms):

--- a/gcfit/scripts/generate_model_CI.py
+++ b/gcfit/scripts/generate_model_CI.py
@@ -52,6 +52,10 @@ def main():
     parser.add_argument('--sampler', default='nested', choices=['nested', 'mcmc'],
                         help='Which sampler was used for the run(s)')
 
+    parser.add_argument('--MF-samples', default=50_000, type=pos_int,
+                        help='Number of samples to use when integrating mass '
+                             'functions')
+
     parser.add_argument('--debug', action='store_true')
 
     args = parser.parse_args()
@@ -76,6 +80,9 @@ def main():
     # ----------------------------------------------------------------------
 
     rc = analysis.RunCollection.from_files(args.filenames, sampler=args.sampler)
+
+    for run in rc:
+        run.obs._MF_M_samples = args.MF_samples
 
     if args.mask:
         mask_prm = args.mask[0]

--- a/gcfit/util/mass.py
+++ b/gcfit/util/mass.py
@@ -64,6 +64,24 @@ class Field:
     shapely : Source for all geometry operations
     '''
 
+    def __getstate__(self):
+
+        if hasattr(self, '_prepped'):
+            self._was_prepped = True
+            del self._prepped
+        else:
+            self._was_prepped = False
+
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__ = d
+
+        if d['_was_prepped']:
+            self.prep()
+
+        del self._was_prepped
+
     def __contains__(self, other):
         # TODO might not be fair to *require* _prepped. Also will error badly
         if self._multi:


### PR DESCRIPTION
Fixes the mass function likelihood calculation to increase the number of samples used to do the required Monte Carlo integration substantially. Using too small a number of samples, in the past, lead to a low precision on each mass function likelihood, and the randomness involved meant the likelihood values were difficult to reproduce.
While this doesn't change most, if any, results, it will improve the reliability of the model fitting.

As the sampling in this integration is not very efficient, rather than re-sampling each time, this also restructures the `valid_likelihoods` of `Observations` to move this responsibility to the beginning, and re-use the samples for any likelihood calculation. This basically amounts to the use of a constant random seed, which is the right way to do this anyways.