### PR TITLE
fix bug in sorting of output files in CI script

### DIFF
--- a/gcfit/scripts/generate_model_CI.py
+++ b/gcfit/scripts/generate_model_CI.py
@@ -49,19 +49,17 @@ def main():
     parser.add_argument('-o', '--output', nargs='+', default=None,
                         help='Alternative files only for saving CI outputs')
 
-    parser.add_argument('--sampler', default='nested', choices=['nested', 'mcmc'],
+    parser.add_argument('--sampler', default='nested',
+                        choices=['nested', 'mcmc'],
                         help='Which sampler was used for the run(s)')
 
-    parser.add_argument('--MF-samples', default=50_000, type=pos_int,
+    parser.add_argument('--MF-samples', default=5000, type=pos_int,
                         help='Number of samples to use when integrating mass '
                              'functions')
 
     parser.add_argument('--debug', action='store_true')
 
     args = parser.parse_args()
-
-    if args.output is None:
-        args.output = args.filenames
 
     if args.debug:
         now = datetime.datetime.now()
@@ -92,5 +90,8 @@ def main():
             run.slice_on_param(mask_prm, mask_dnlim, mask_uplim)
 
     mc = rc.get_CImodels(N=args.N, Nprocesses=args.Ncpu, load=False)
+
+    if args.output is None:
+        args.output = [rv._filename for rv in rc]
 
     mc.save(args.output, overwrite=args.overwrite)


### PR DESCRIPTION
Fixes a small bug in the `generate_model_CI` script which caused the model outputs to be saved to the wrong files sometimes.

If multiple filenames were given to this script which were out of order, the runs and models themselves would be sorted by cluster name, but the names of the output files to save the CI results to would not be. This caused the CIs to be placed in the output files for the wrong clusters.
This is a simple fix by using the filenames from the `RunCollection` objects directly.