### PR TITLE
stop validating likelihoods when filtering dataset

### DIFF
--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -434,7 +434,7 @@ class Observations:
 
         return groups
 
-    def filter_datasets(self, pattern, valid_only=True):
+    def filter_datasets(self, pattern, valid_only=False):
         '''Return a subset of `Observations.datasets` based on given `pattern`
 
         Parameters


### PR DESCRIPTION
`filter_datasets` was by default using the "only valid" datasets logic, which in turn prepped the datasets for use in likelihoods and called the expensive MF sampling function.
Considering this is only ever used in the plotting to determine what datasets exist (other places call `filter_likelihoods` instead), there is no need for the more expensive operation to be called by default.