### PR TITLE
Hotfix/multipanel plots

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -93,7 +93,74 @@ class _ClusterVisualizer:
     def _setup_multi_artist(self, fig, shape, *, allow_blank=True,
                             use_name=True, constrained_layout=True,
                             subfig_kw=None, **sub_kw):
-        '''setup a subplot with multiple axes'''
+        '''setup a figure with multiple axes, using subplots or subfigures
+
+        Given a desired shape tuple, returns a figure with the correct
+        arrangement of axes. Allows for easily specifying slightly more complex
+        arrangements of axes while filling out the figure space, without the
+        use of functions like `subplot_mosaic`.
+
+        The requested shape will determine the exact configuration of the
+        returned figure, with subfigures being used in cases where the number
+        of axes in a given row or column is mismatched, and otherwise only
+        subplots being used. All created axes are returned in a flat array,
+        as given by `fig.axes`.
+
+        If `shape` is a length 1 tuple, will create N rows. If a length 2
+        tuple, will create (Nrows, Ncols) subplots. If either Nrows or Ncols
+        is itself a 2-tuple, will create the number of subfigures (either rows
+        or columns) specified by the other value and fill each with the number
+        of axes specified in the corresponding tuple. The axes will fill the
+        entire space provided by each row/column, and not necessarily be
+        aligned along subfigures.
+        Nrows and Ncols cannot both be tuples at once.
+
+        For example:
+        (3,) -> Single column with 3 rows
+        (3,2) -> 3 row, 2 column subplot
+        (2,(1,3)) -> 2 rows of subfigures, with 1 and 3 columns each
+        ((1,3,4), 3) -> 3 columns of subfigures, with 1, 3 and 4 rows each
+        ((1,3,4), 4) -> if `allow_blank`, same as above with an empty 4th column
+
+        Parameters
+        ----------
+        fig : None or matplotlib.figure.Figure
+            Given starting figure. If None will create a new figure from
+            scratch. If given an existing `Figure` with existing axes, will
+            simply check that axes shape matches and return the figure
+            untouched If `Figure` is empty (no axes), will create new axes
+            within the given figure.
+
+        shape : tuple
+            Tuple representing the shape of the subplot grid.
+
+        allow_blank : bool, optional
+            If shape requires subfigures and the number of subfigures is larger
+            than the corresponding tuple, allow the creation of blank (empty)
+            subfigures on the end. Defaults to True.
+
+        use_name : bool, optional
+            If True (default) add `self.name` to the figure suptitle.
+
+        constrained_layout : bool, optional
+            Passed to `Figure` if a new figure must be created. Defaults to
+            True.
+
+        subfig_kw : dict, optional
+            Passed to `fig.subfigures`, if required.
+
+        **subkw : dict, optional
+            Extra arguments passed to all calls to `fig.subplots`.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            The created figure.
+
+        axes : array of matplotlib.axes.AxesSubplot
+            Flattened numpy array of all axes in `fig`, as given by `fig.axes`
+
+        '''
 
         if subfig_kw is None:
             subfig_kw = {}
@@ -120,6 +187,7 @@ class _ClusterVisualizer:
                         if allow_blank:
                             continue
 
+                        # TODO this still creates the figure...
                         mssg = (f"Number of row entries {shape['nrows']} must "
                                 f"match number of columns ({shape['ncols']})")
                         raise ValueError(mssg)
@@ -175,7 +243,6 @@ class _ClusterVisualizer:
             # make sure shape is a tuple of atleast 1d, at most 2d
 
             if not isinstance(shape, tuple):
-                # TODO doesnt work on an int
                 shape = tuple(shape)
 
             if len(shape) == 1:

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -1277,6 +1277,12 @@ class _ClusterVisualizer:
         if self.obs is None:
             show_obs = False
 
+        if self.mass_func is None:
+            # Should only occur for ObservationsVisualizer with no MF data
+            #   at which point I'm not sure what you're even trying to plot
+            #   (this avoids a very ugly error)
+            raise ValueError("No mass function data exists to plot")
+
         # ------------------------------------------------------------------
         # Setup axes, splitting into two columns if necessary and adding the
         # extra ax for the field plot if desired
@@ -1285,7 +1291,11 @@ class _ClusterVisualizer:
         ax_ind = 0
 
         N_rbins = sum([len(d) for d in self.mass_func.values()])
-        shape = ((int(np.ceil(N_rbins / 2)), int(np.floor(N_rbins / 2))), 2)
+
+        if N_rbins > 5:
+            shape = ((int(np.ceil(N_rbins / 2)), int(np.floor(N_rbins / 2))), 2)
+        else:
+            shape = ((N_rbins, ), 1)  # this format ensures subfigs are created
 
         # If adding the fields, include an extra column on the left for it
         if show_fields:
@@ -3196,6 +3206,10 @@ class ObservationsVisualizer(_ClusterVisualizer):
         cen = (observations.mdata['RA'], observations.mdata['DEC'])
 
         PI_list = observations.filter_datasets('*mass_function*')
+
+        if not PI_list:
+            self.mass_func = None
+            return
 
         for i, (key, mf) in enumerate(PI_list.items()):
 

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -96,24 +96,7 @@ class _RunAnalysis:
             subfig_kw = {}
 
         def create_axes(base, shape):
-            '''create the axes of `shape` on this base (fig)'''
-
-            # make sure shape is a tuple of atleast 1d, at most 2d
-
-            if not isinstance(shape, tuple):
-                # TODO doesnt work on an int
-                shape = tuple(shape)
-
-            if len(shape) == 1:
-                shape = (shape, 1)
-
-            elif len(shape) > 2:
-                mssg = f"Invalid `shape` for subplots {shape}, must be 2D"
-                raise ValueError(mssg)
-
-            # split into dict of nrows, ncols
-
-            shape = dict(zip(("nrows", "ncols"), shape))
+            '''create the axes of `shape` on this base (fig). shape as dict'''
 
             # if either of them is also a tuple, means we want columns or rows
             #   of varying sizes, switch to using subfigures
@@ -186,12 +169,36 @@ class _RunAnalysis:
 
         else:
 
+            # make sure shape is a tuple of atleast 1d, at most 2d
+
+            if not isinstance(shape, tuple):
+                # TODO doesnt work on an int
+                shape = tuple(shape)
+
+            if len(shape) == 1:
+                shape = (shape, 1)
+
+            elif len(shape) > 2:
+                mssg = f"Invalid `shape` for subplots {shape}, must be 2D"
+                raise ValueError(mssg)
+
+            # split into dict of nrows, ncols
+
+            shape = dict(zip(("nrows", "ncols"), shape))
+
             # this fig has axes, check that they match shape
             if axarr := fig.axes:
-                # TODO this won't actually work, cause fig.axes is just a list
-                if axarr.shape != shape:
-                    mssg = (f"figure {fig} already contains axes with "
-                            f"mismatched shape ({axarr.shape} != {shape})")
+
+                if isinstance(shape['nrows'], tuple):
+                    Naxes = np.sum(shape['nrows'])
+                elif isinstance(shape['ncols'], tuple):
+                    Naxes = np.sum(shape['ncols'])
+                else:
+                    Naxes = shape['nrows'] * shape['ncols']
+
+                if len(axarr) != Naxes:
+                    mssg = (f"figure {fig} already contains wrong number of "
+                            f"axes ({len(axarr)} != {Naxes})")
                     raise ValueError(mssg)
 
             else:


### PR DESCRIPTION
Fix a number of bugs related to a few of the multi-panel plots, especially to do with when multiple plots should be split into two rows or not.
Also brings both `models` and `runs` and `NestedRun` and `MCMCrun` into more uniformity with each other slightly.