### PR TITLE
remove specific version requirements for docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # required to build docs
-sphinx==4.4.0
-numpydoc==1.1.0
-pydata-sphinx-theme==0.8.0
-sphinx_toggleprompt==0.0.5
+sphinx
+numpydoc
+pydata-sphinx-theme
+sphinx_toggleprompt


### PR DESCRIPTION
Removes version requirements from `docs/requirements.txt` to ensure the documentation dependencies like sphinx don't become outdated.