### PR TITLE
Feature/artpop integration

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -3337,6 +3337,9 @@ class ObservationsVisualizer(_ClusterVisualizer):
 # --------------------------------------------------------------------------
 
 class SampledVisualizer:
+    '''
+    basic class for making some plots related to a sampled single model
+    '''
 
     _setup_artist = _ClusterVisualizer._setup_artist
 
@@ -3434,7 +3437,15 @@ class SampledVisualizer:
                         ideal_imager=False, exptime=3600,
                         imager_kw=None, psf_kw=None,
                         observe_kw=None, rgb_kw=None, show_kw=None):
-        '''plot a simulated observation using `artpop`'''
+        '''plot a simulated observation using `artpop`
+
+        This method basically provides a skeleton of what is necessary to
+        produce an artpop artificial RGB image of a sampled cluster, based on
+        the `SampledModel.to_artpop` method.
+        All options for each step can be provided to the relevant `*_kw`
+        argument. If more manual control is required, simply use the
+        `artpop.Source` provided by `to_artpop` directly.
+        '''
         import artpop
         from astropy.visualization import make_lupton_rgb
 

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -16,7 +16,7 @@ from collections import abc
 
 
 __all__ = ['ModelVisualizer', 'CIModelVisualizer', 'ObservationsVisualizer',
-           'ModelCollection']
+           'SampledVisualizer', 'ModelCollection']
 
 
 def _get_model(theta, observations):
@@ -58,13 +58,13 @@ class _ClusterVisualizer:
     # Artist setups
     # -----------------------------------------------------------------------
 
-    def _setup_artist(self, fig, ax, *, use_name=True):
+    def _setup_artist(self, fig, ax, *, use_name=True, **sub_kw):
         '''setup a plot (figure and ax) with one single ax'''
 
         if ax is None:
             if fig is None:
                 # no figure or ax provided, make one here
-                fig, ax = plt.subplots()
+                fig, ax = plt.subplots(**sub_kw)
 
             else:
                 # Figure provided, no ax provided. Try to grab it from the fig
@@ -78,7 +78,7 @@ class _ClusterVisualizer:
                     ax = cur_axes[0]
 
                 else:
-                    ax = fig.add_subplot()
+                    ax = fig.add_subplot(**sub_kw)
 
         else:
             if fig is None:
@@ -3329,6 +3329,101 @@ class ObservationsVisualizer(_ClusterVisualizer):
         self.K_scale = None
 
         self._init_massfunc(observations)
+
+
+# --------------------------------------------------------------------------
+# Sampled Model visualizers
+# --------------------------------------------------------------------------
+
+class SampledVisualizer:
+
+    _setup_artist = _ClusterVisualizer._setup_artist
+
+    def _get_stars(self, type_='all'):
+
+        mask = np.full(self.model.N, False)
+
+        if type_ == 'all':
+            mask[:] = True
+        else:
+            mask[mask == type_] = True
+
+        mask[::self.thin] = False
+
+        return mask
+
+    def __init__(self, sampledmodel, thin=1):
+
+        self.model = sampledmodel
+        self.thin = thin
+
+    def plot_positions(self, fig=None, ax=None, type_='all',
+                       galactic=False, projection=None, **kwargs):
+
+        subplot_kw = dict(projection=projection)
+
+        fig, ax = self._setup_artist(fig=fig, ax=ax, subplot_kw=subplot_kw)
+
+        mask = self._get_stars(type_)
+
+        if galactic:
+
+            x = self.model.galactic.lon[mask]
+            y = self.model.galactic.lat[mask]
+            z = self.model.galactic.distance[mask]
+
+        elif projection == 'polar':
+
+            x = self.model.pos.r[mask]
+            y = self.model.pos.theta[mask]
+            z = None  # can't be polar and 3d
+
+        else:
+
+            x = self.model.pos.x[mask]
+            y = self.model.pos.y[mask]
+            z = self.model.pos.y[mask]
+
+        if projection == '3d':
+            ax.scatter(x, y, z, **kwargs)
+        else:
+            ax.scatter(x, y, **kwargs)
+
+        return fig
+
+    def plot_velocities(self, fig=None, ax=None, type_='all',
+                        galactic=False, projection=None, **kwargs):
+
+        subplot_kw = dict(projection=projection)
+
+        fig, ax = self._setup_artist(fig=fig, ax=ax, subplot_kw=subplot_kw)
+
+        mask = self._get_stars(type_)
+
+        if galactic:
+
+            vx = self.model.galactic.pm_l_cosb[mask]
+            vy = self.model.galactic.pm_b[mask]
+            vz = self.model.galactic.v_los[mask]
+
+        elif projection == 'polar':
+
+            vx = self.model.vel.r[mask]
+            vy = self.model.vel.theta[mask]
+            vz = None  # can't be polar and 3d
+
+        else:
+
+            vx = self.model.vel.x[mask]
+            vy = self.model.vel.y[mask]
+            vz = self.model.vel.y[mask]
+
+        if projection == '3d':
+            ax.scatter(vx, vy, vz, **kwargs)
+        else:
+            ax.scatter(vx, vy, **kwargs)
+
+        return fig
 
 
 # --------------------------------------------------------------------------

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -3356,6 +3356,7 @@ class SampledVisualizer:
     def __init__(self, sampledmodel, thin=1):
 
         self.model = sampledmodel
+        self.d = sampledmodel.d
         self.thin = thin
 
     def plot_positions(self, fig=None, ax=None, type_='all',
@@ -3426,6 +3427,7 @@ class SampledVisualizer:
 
         return fig
 
+    @_ClusterVisualizer._support_units
     def plot_simulation(self, phot_system, r_band, g_band, b_band,
                         pixel_scale, FWHM,
                         fig=None, ax=None, *, source_kw=None,

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -55,7 +55,7 @@ class _RunAnalysis:
             mssg = f"{cm} is not a registered colormap, see `plt.colormaps`"
             raise ValueError(mssg)
 
-   def _setup_artist(self, fig, ax, *, use_name=True, **sub_kw):
+    def _setup_artist(self, fig, ax, *, use_name=True, **sub_kw):
         '''setup a plot (figure and ax) with one single ax'''
 
         if ax is None:

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -55,13 +55,13 @@ class _RunAnalysis:
             mssg = f"{cm} is not a registered colormap, see `plt.colormaps`"
             raise ValueError(mssg)
 
-    def _setup_artist(self, fig, ax, *, use_name=True):
+   def _setup_artist(self, fig, ax, *, use_name=True, **sub_kw):
         '''setup a plot (figure and ax) with one single ax'''
 
         if ax is None:
             if fig is None:
                 # no figure or ax provided, make one here
-                fig, ax = plt.subplots()
+                fig, ax = plt.subplots(**sub_kw)
 
             else:
                 # Figure provided, no ax provided. Try to grab it from the fig
@@ -75,7 +75,7 @@ class _RunAnalysis:
                     ax = cur_axes[0]
 
                 else:
-                    ax = fig.add_subplot()
+                    ax = fig.add_subplot(**sub_kw)
 
         else:
             if fig is None:

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -2625,9 +2625,9 @@ class RunCollection(_RunAnalysis):
         math_mapping = {
             'W0': r'\hat{\phi}_0',
             'M': r'M',
-            'rh': r'r_{h}',
-            'ra': (r'r_{a}' if force_model
-                   else r'\log_{10}\left(\hat{r}_{a}\right)'),
+            'rh': r'r_{\mathrm{h}}',
+            'ra': (r'r_{\mathrm{a}}' if force_model
+                   else r'\log_{10}\left(\hat{r}_{\mathrm{a}}\right)'),
             'g': r'g',
             'delta': r'\delta',
             's2': r's^{2}',
@@ -2642,17 +2642,17 @@ class RunCollection(_RunAnalysis):
             'RA': r'\mathrm{RA}',
             'DEC': r'\mathrm{DEC}',
             'chi2': r'\chi^{2}',
-            'BH_mass': r'\mathrm{M}_{BH}',
-            'BH_num': r'\mathrm{N}_{BH}',
+            'BH_mass': r'\mathrm{M}_{\mathrm{BH}}',
+            'BH_num': r'\mathrm{N}_{\mathrm{BH}}',
             'f_rem': r'f_{\mathrm{remn}}',
             'f_BH': r'f_{\mathrm{BH}}',
             'spitzer_chi': r'\chi_{\mathrm{Spitzer}}',
             'trh': r't_{\mathrm{r_h}}',
             'N_relax': r'N_{\mathrm{relax}}',
             'r0': r'r_{0}',
-            'rt': r'r_{t}',
-            'rv': r'r_{v}',
-            'rhp': r'r_{hp}',
+            'rt': r'r_{\mathrm{t}}',
+            'rv': r'r_{\mathrm{v}}',
+            'rhp': r'r_{\mathrm{hp}}',
             'mmean': r'\bar{m}',
         }
 
@@ -3513,14 +3513,19 @@ class RunCollection(_RunAnalysis):
 
         return fig
 
-    def summary_dataframe(self, *, include_FeH=True, include_BH=False,
+    def summary_dataframe(self, *, params='all',
+                          include_FeH=True, include_BH=False,
                           math_labels=False):
         import pandas as pd
         # TODO pandas isn't in the setup requirements
 
         # Get name of all desired parameters
 
-        labels = self.runs[0]._get_labels(label_fixed=False)
+        if params == 'all':
+            labels = self.runs[0]._get_labels(label_fixed=False)
+
+        else:
+            labels = params
 
         if include_FeH:
             labels = ['FeH'] + labels
@@ -3548,7 +3553,7 @@ class RunCollection(_RunAnalysis):
 
         return pd.DataFrame.from_dict(data)
 
-    def output_summary(self, outfile=sys.stdout, style='latex', *,
+    def output_summary(self, outfile=sys.stdout, params='all', style='latex', *,
                        include_FeH=False, include_BH=False, math_labels=False,
                        substack_errors=False, **kwargs):
         '''output a table of all parameter means for each cluster'''
@@ -3576,7 +3581,8 @@ class RunCollection(_RunAnalysis):
 
         # get dataframe
 
-        df = self.summary_dataframe(include_FeH=include_FeH,
+        df = self.summary_dataframe(params=params,
+                                    include_FeH=include_FeH,
                                     include_BH=include_BH,
                                     math_labels=math_labels)
 

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -2226,8 +2226,8 @@ class SampledModel:
             the units will be assumed to be `arcsec / pixels`.
 
         a_lam : float or dict, optional
-            Magnitude of extinction. If float, the same extinction will be applied
-            to all bands. If dict, keys must match filters for this
+            Magnitude of extinction. If float, the same extinction will be
+            applied to all bands. If dict, keys must match filters for this
             `phot_system` and will be applied individually, defaulting to 0 for
             missing filters.
 
@@ -2301,30 +2301,32 @@ class SampledModel:
         # Get positions
         # ------------------------------------------------------------------
 
-        if projected:
-            try:
-                dist = self.galactic.distance[isolim_mask].to('kpc')
+        with u.set_enabled_equivalencies(util.angular_width(self.d)):
 
-                x = self.galactic.lon[isolim_mask].to('arcsec')
-                y = self.galactic.lat[isolim_mask].to('arcsec')
+            if projected:
+                try:
+                    dist = self.galactic.distance[isolim_mask].to('kpc')
 
-                rem_x = self.galactic.lon[~self.star_mask].to('arcsec')
-                rem_y = self.galactic.lat[~self.star_mask].to('arcsec')
+                    x = self.galactic.lon[isolim_mask].to('arcsec')
+                    y = self.galactic.lat[isolim_mask].to('arcsec')
+
+                    rem_x = self.galactic.lon[~self.star_mask].to('arcsec')
+                    rem_y = self.galactic.lat[~self.star_mask].to('arcsec')
+                    rem_t = self.star_types[~self.star_mask]
+
+                except AttributeError:
+                    mssg = ("Model has not been projected. Supply a "
+                            "'centre' at init or set 'projected=False' here")
+                    raise ValueError(mssg)
+
+            else:
+                dist = (self.d + self.pos.z[isolim_mask]).to('kpc')
+                x = self.pos.x[isolim_mask].to('arcsec')
+                y = self.pos.y[isolim_mask].to('arcsec')
+
+                rem_x = self.pos.x[~self.star_mask].to('arcsec')
+                rem_y = self.pos.y[~self.star_mask].to('arcsec')
                 rem_t = self.star_types[~self.star_mask]
-
-            except AttributeError:
-                mssg = ("Model has not been projected. Supply a "
-                        "'centre' at init or set 'projected=False' here")
-                raise ValueError(mssg)
-
-        else:
-            dist = (self.d + self.pos.z[isolim_mask]).to('kpc')
-            x = self.pos.x[isolim_mask].to('arcsec')
-            y = self.pos.y[isolim_mask].to('arcsec')
-
-            rem_x = self.pos.x[~self.star_mask].to('arcsec')
-            rem_y = self.pos.y[~self.star_mask].to('arcsec')
-            rem_t = self.star_types[~self.star_mask]
 
         if cutoff_radius is not None:
             cutmask = (x**2 + y**2)**0.5 < cutoff_radius

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -2220,7 +2220,7 @@ class SampledModel:
     # artpop tests
     # ----------------------------------------------------------------------
 
-    def to_artpop(self, phot_system, pixel_scale, *,
+    def to_artpop(self, phot_system, pixel_scale, *, thin=False,
                   a_lam=0., projected=True, cutoff_radius=None,
                   return_rem=False, iso_class=None, **kwargs):
         import artpop
@@ -2299,6 +2299,12 @@ class SampledModel:
             rem_t = rem_t[remcutmask]
 
         dpi = u.pixel_scale(pixel_scale)
+
+        if thin:
+            x = x[::thin]
+            y = y[::thin]
+            dist = dist[::thin]
+            masses = masses[::thin]
 
         # Put on the required positive grid for artpop
         xm, ym = x.min(), y.min()

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1080,9 +1080,9 @@ class Model(lp.limepy):
                         "an `observations`, to read them from"}
                 raise ValueError(mssg)
 
-        self.age <<= u.Gyr
+        self.age = age << u.Gyr
         self.FeH = FeH
-        self.vesc <<= (u.km / u.s)
+        self.vesc = vesc << (u.km / u.s)
 
         self.observations = observations
 

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -2348,6 +2348,8 @@ class SampledModel:
         # Put on the required positive grid for artpop
         xm, ym = x.min(), y.min()
 
+        pixel_scale <<= u.arcsec / u.pixel
+
         dpi = u.pixel_scale(pixel_scale)
 
         x = (x - xm).to(u.pix, dpi)

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1080,8 +1080,9 @@ class Model(lp.limepy):
                         "an `observations`, to read them from"}
                 raise ValueError(mssg)
 
-        age <<= u.Gyr
-        vesc <<= (u.km / u.s)
+        self.age <<= u.Gyr
+        self.FeH = FeH
+        self.vesc <<= (u.km / u.s)
 
         self.observations = observations
 
@@ -1093,8 +1094,8 @@ class Model(lp.limepy):
             m_breaks=m_breaks.value,
             a_slopes=[-a1, -a2, -a3],
             nbins=nbins,
-            FeH=FeH,
-            tout=np.array([age.to_value('Myr')]),
+            FeH=self.FeH,
+            tout=np.array([self.age.to_value('Myr')]),
             Ndot=Ndot,
             N0=5e5,
             tcc=tcc,
@@ -1102,7 +1103,7 @@ class Model(lp.limepy):
             BH_ret_int=BH_ret_int,
             BH_ret_dyn=BHret / 100.,
             natal_kicks=natal_kicks,
-            vesc=vesc.value
+            vesc=self.vesc.value
         )
 
         self._mf = EvolvedMF(**self._mf_kwargs)
@@ -1236,7 +1237,7 @@ class Model(lp.limepy):
 
         # Elapsed relaxations
 
-        self.N_relax = age.to('Gyr') / self.trh
+        self.N_relax = self.age.to('Gyr') / self.trh
 
         # Spitzer instability
 
@@ -2135,11 +2136,8 @@ class SampledModel:
         self.s2j = np.repeat(model.s2j, self.Nj)
         self.σ2_factor = model.s2 / self.s2j
 
-        try:
-            self.age = model.observations.mdata['age'] << u.Gyr
-            self.feh = model.observations.mdata['FeH']
-        except (AttributeError, KeyError):
-            pass
+        self.age = model.age
+        self.FeH = model.FeH
 
         # ------------------------------------------------------------------
         # "Sample" the masses, assuming all stars are exactly mean bin mass

--- a/gcfit/util/units.py
+++ b/gcfit/util/units.py
@@ -1,6 +1,6 @@
 import warnings
 
-import scipy.stats
+import scipy
 import numpy as np
 import astropy.units as u
 from astropy.units.equivalencies import Equivalency


### PR DESCRIPTION
Adds some ability for sampled models to be used to produce artificial cluster images, using the [`artpop`](https://artpop.readthedocs.io/) package, by adding the `SampledModel.to_artpop` method which manually produces an `artpop.Source` object based on the sampled positions and masses.