### PR TITLE
make adding a legend to profile plots optional

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -548,7 +548,7 @@ class _ClusterVisualizer:
                            label=label, **kwargs)
 
     def _plot_profile(self, ax, ds_pattern, y_key, model_data, *,
-                      y_unit=None, residuals=False,
+                      y_unit=None, residuals=False, legend=False,
                       res_kwargs=None, data_kwargs=None, model_kwargs=None,
                       color=None, data_color=None, model_color=None,
                       mass_bins=None, label_masses=True, model_label=None,
@@ -708,6 +708,12 @@ class _ClusterVisualizer:
         # Adjust x limits
         if self.rlims is not None:
             ax.set_xlim(*self.rlims)
+
+        # Create legend (remove if no handles found)
+        if legend:
+            leg = ax.legend()
+            if not leg.legendHandles:
+                leg.remove()
 
         return ax, res_ax
 
@@ -900,7 +906,7 @@ class _ClusterVisualizer:
     @_support_units
     def plot_LOS(self, fig=None, ax=None,
                  show_obs=True, residuals=False, *,
-                 x_unit='pc', y_unit='km/s',
+                 x_unit='pc', y_unit='km/s', legend=True,
                  label_position='top', verbose_label=True, blank_xaxis=False,
                  res_kwargs=None, **kwargs):
 
@@ -919,7 +925,8 @@ class _ClusterVisualizer:
         ax, res_ax = self._plot_profile(ax, pattern, var, self.LOS,
                                         strict=strict, residuals=residuals,
                                         x_unit=x_unit, y_unit=y_unit,
-                                        res_kwargs=res_kwargs, **kwargs)
+                                        legend=legend, res_kwargs=res_kwargs,
+                                        **kwargs)
 
         if verbose_label:
             label = 'LOS Velocity Dispersion'
@@ -930,17 +937,12 @@ class _ClusterVisualizer:
         self._set_xlabel(ax, unit=x_unit, residual_ax=res_ax,
                          remove_all=blank_xaxis)
 
-        leg = ax.legend()
-        # Remove empty legend boxes. TODO must be a better way to check this
-        if not leg.legendHandles:
-            leg.remove()
-
         return fig
 
     @_support_units
     def plot_pm_tot(self, fig=None, ax=None,
                     show_obs=True, residuals=False, *,
-                    x_unit='pc', y_unit='mas/yr',
+                    x_unit='pc', y_unit='mas/yr', legend=True,
                     label_position='top', verbose_label=True, blank_xaxis=False,
                     res_kwargs=None, **kwargs):
 
@@ -959,7 +961,8 @@ class _ClusterVisualizer:
         ax, res_ax = self._plot_profile(ax, pattern, var, self.pm_tot,
                                         strict=strict, residuals=residuals,
                                         x_unit=x_unit, y_unit=y_unit,
-                                        res_kwargs=res_kwargs, **kwargs)
+                                        legend=legend, res_kwargs=res_kwargs,
+                                        **kwargs)
 
         if verbose_label:
             label = "Total PM Dispersion"
@@ -970,16 +973,12 @@ class _ClusterVisualizer:
         self._set_xlabel(ax, unit=x_unit, residual_ax=res_ax,
                          remove_all=blank_xaxis)
 
-        leg = ax.legend()
-        if not leg.legendHandles:
-            leg.remove()
-
         return fig
 
     @_support_units
     def plot_pm_ratio(self, fig=None, ax=None,
                       show_obs=True, residuals=False, *,
-                      x_unit='pc', blank_xaxis=False,
+                      x_unit='pc', blank_xaxis=False, legend=True,
                       label_position='top', verbose_label=True,
                       res_kwargs=None, **kwargs):
 
@@ -997,7 +996,7 @@ class _ClusterVisualizer:
 
         ax, res_ax = self._plot_profile(ax, pattern, var, self.pm_ratio,
                                         strict=strict, residuals=residuals,
-                                        x_unit=x_unit,
+                                        x_unit=x_unit, legend=True,
                                         res_kwargs=res_kwargs, **kwargs)
 
         if verbose_label:
@@ -1010,16 +1009,12 @@ class _ClusterVisualizer:
         self._set_xlabel(ax, unit=x_unit, residual_ax=res_ax,
                          remove_all=blank_xaxis)
 
-        leg = ax.legend()
-        if not leg.legendHandles:
-            leg.remove()
-
         return fig
 
     @_support_units
     def plot_pm_T(self, fig=None, ax=None,
                   show_obs=True, residuals=False, *,
-                  x_unit='pc', y_unit='mas/yr',
+                  x_unit='pc', y_unit='mas/yr', legend=True,
                   label_position='top', verbose_label=True, blank_xaxis=False,
                   res_kwargs=None, **kwargs):
 
@@ -1038,7 +1033,8 @@ class _ClusterVisualizer:
         ax, res_ax = self._plot_profile(ax, pattern, var, self.pm_T,
                                         strict=strict, residuals=residuals,
                                         x_unit=x_unit, y_unit=y_unit,
-                                        res_kwargs=res_kwargs, **kwargs)
+                                        legend=legend, res_kwargs=res_kwargs,
+                                        **kwargs)
 
         if verbose_label:
             label = "Tangential PM Dispersion"
@@ -1049,16 +1045,12 @@ class _ClusterVisualizer:
         self._set_xlabel(ax, unit=x_unit, residual_ax=res_ax,
                          remove_all=blank_xaxis)
 
-        leg = ax.legend()
-        if not leg.legendHandles:
-            leg.remove()
-
         return fig
 
     @_support_units
     def plot_pm_R(self, fig=None, ax=None,
                   show_obs=True, residuals=False, *,
-                  x_unit='pc', y_unit='mas/yr',
+                  x_unit='pc', y_unit='mas/yr', legend=True,
                   label_position='top', verbose_label=True, blank_xaxis=False,
                   res_kwargs=None, **kwargs):
 
@@ -1077,7 +1069,8 @@ class _ClusterVisualizer:
         ax, res_ax = self._plot_profile(ax, pattern, var, self.pm_R,
                                         strict=strict, residuals=residuals,
                                         x_unit=x_unit, y_unit=y_unit,
-                                        res_kwargs=res_kwargs, **kwargs)
+                                        legend=legend, res_kwargs=res_kwargs,
+                                        **kwargs)
 
         if verbose_label:
             label = "Radial PM Dispersion"
@@ -1088,16 +1081,12 @@ class _ClusterVisualizer:
         self._set_xlabel(ax, unit=x_unit, residual_ax=res_ax,
                          remove_all=blank_xaxis)
 
-        leg = ax.legend()
-        if not leg.legendHandles:
-            leg.remove()
-
         return fig
 
     @_support_units
     def plot_number_density(self, fig=None, ax=None,
                             show_background=False, subtract_background=False,
-                            show_obs=True, residuals=False, *,
+                            show_obs=True, residuals=False, *, legend=True,
                             x_unit='pc', y_unit='1/pc2', scale_to='model',
                             label_position='top', verbose_label=True,
                             blank_xaxis=False, res_kwargs=None,
@@ -1203,17 +1192,14 @@ class _ClusterVisualizer:
         ax, res_ax = self._plot_profile(ax, pattern, var, self.numdens,
                                         strict=strict, residuals=residuals,
                                         x_unit=x_unit, y_unit=y_unit,
+                                        legend=legend,
                                         model_kwargs=model_kwargs,
                                         data_kwargs=data_kwargs,
                                         res_kwargs=res_kwargs, **kwargs)
 
         # ------------------------------------------------------------------
-        # Add legends and labels
+        # Add labels
         # ------------------------------------------------------------------
-
-        leg = ax.legend()
-        if not leg.legendHandles:
-            leg.remove()
 
         if verbose_label:
             label = 'Number Density'

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -7,6 +7,7 @@ import numpy as np
 import astropy.units as u
 import matplotlib.pyplot as plt
 import matplotlib.colors as mpl_clr
+import matplotlib.legend as mpl_leg
 import matplotlib.ticker as mpl_tick
 import astropy.visualization as astroviz
 
@@ -711,9 +712,13 @@ class _ClusterVisualizer:
 
         # Create legend (remove if no handles found)
         if legend:
-            leg = ax.legend()
-            if not leg.legendHandles:
-                leg.remove()
+
+            # The empty legends warning is apparently impossible to catch, so
+            # we'll do it ourselves, and save the stdout clutter
+            handles, labels = mpl_leg._get_legend_handles_labels([ax])
+
+            if len(handles) > 0:
+                ax.legend(handles, labels)
 
         return ax, res_ax
 


### PR DESCRIPTION
Switches the responsibility for adding legends from the individual profile functions into the `_plot_profile` function itself, and then supports passing in a flag to ignore the legends completely in all those functions.