### PR TITLE
Fix import of scipy trapezoid.

### DIFF
--- a/gcfit/util/probabilities.py
+++ b/gcfit/util/probabilities.py
@@ -101,11 +101,11 @@ def trim_peaks(az_domain, Paz):
     '''Remove all "peaks" from distribution while maintaining normalization.'''
 
     from scipy.signal import find_peaks
-    from scipy.integrate import trapz
+    from scipy.integrate import trapezoid
 
     Paz = Paz.copy()
 
-    while (area := trapz(x=az_domain.value, y=Paz.value)) >= 0.98:
+    while (area := trapezoid(x=az_domain.value, y=Paz.value)) >= 0.98:
 
         peaks, _ = find_peaks(Paz, height=0, threshold=1e5, width=1)
 


### PR DESCRIPTION
`scipy.integrate.trapz` was deprecated in SciPy 1.14 in favour of `scipy.integrate.trapezoid`.