### PR TITLE
Fixes to pulsar likelihoods.

### DIFF
--- a/docs/source/fitting.rst
+++ b/docs/source/fitting.rst
@@ -216,6 +216,11 @@ where the intrinsic spin-down of pulsars
 fields of the host cluster and galaxy, and the Shklovskii (proper motion) all
 combine in the observed spin-down of the pulsar timing solution. 
 
+We adopt the
+`MilkyWayPotential2022 <https://gala.adrian.pw/en/latest/api/gala.potential.potential.MilkyWayPotential2022.html>`_
+potential from `gala <https://gala.adrian.pw/en/latest/index.html>`_ to model
+the contribution of the galactic potential.
+
 The intrinsic spin-down of the observed pulsars is assumed to be identical to
 pulsars found in the galaxy, outside of clusters, and dependant only on their
 period. The field pulsars, as they are unaffected by the cluster potential,

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -287,7 +287,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
 
         # normalize conv2 to the PdotP_tot domain
         conv2 /= util.QuantitySpline(
-            lin_domain, conv2, k=1, s=0, ext=1
+            PdotP_tot, conv2, k=1, s=0, ext=1
         ).integral(-np.inf, np.inf)
 
         prob_dist = util.QuantitySpline(PdotP_tot, conv2, k=1, s=0, ext=1)
@@ -488,7 +488,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         PdotP_tot = (lin_domain / Pb) + PdotP_pm + PdotP_gal
 
         # normalize conv to the PdotP_tot domain
-        conv /= util.QuantitySpline(lin_domain, conv, k=1, s=0, ext=1).integral(
+        conv /= util.QuantitySpline(PdotP_tot, conv, k=1, s=0, ext=1).integral(
             -np.inf, np.inf
         )
 

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -264,10 +264,6 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
 
         conv2 = np.convolve(conv1, Pdot_int_spl(lin_domain), 'same')
 
-        # Normalize
-        conv2 /= util.QuantitySpline(
-            lin_domain, conv2, k=1, s=0, ext=1
-        ).integral(-np.inf, np.inf)
 
         # ------------------------------------------------------------------
         # Compute the Shklovskii (proper motion) effect component
@@ -287,10 +283,14 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         # Interpolate the likelihood value from the overall distribution
         # ------------------------------------------------------------------
 
-        prob_dist = interp.interp1d(
-            (lin_domain / P) + PdotP_pm + PdotP_gal, conv2,
-            assume_sorted=True, bounds_error=False, fill_value=0.0
-        )
+        PdotP_tot = (lin_domain / P) + PdotP_pm + PdotP_gal
+
+        # normalize conv2 to the PdotP_tot domain
+        conv2 /= util.QuantitySpline(
+            lin_domain, conv2, k=1, s=0, ext=1
+        ).integral(-np.inf, np.inf)
+
+        prob_dist = util.QuantitySpline(PdotP_tot, conv2, k=1, s=0, ext=1)
 
         probs[i] = prob_dist((Pdot_meas / P).decompose())
 
@@ -466,10 +466,6 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         # conv = np.convolve(err, PdotP_c_prob, 'same')
         conv = np.convolve(err, Pdot_c_spl(lin_domain), 'same')
 
-        # Normalize
-        conv /= util.QuantitySpline(lin_domain, conv, k=1, s=0, ext=1).integral(
-            -np.inf, np.inf
-        )
 
         # ------------------------------------------------------------------
         # Compute the Shklovskii (proper motion) effect component
@@ -489,10 +485,14 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         # Interpolate the likelihood value from the overall distribution
         # ------------------------------------------------------------------
 
-        prob_dist = interp.interp1d(
-            (lin_domain / Pb) + PdotP_pm + PdotP_gal, conv,
-            assume_sorted=True, bounds_error=False, fill_value=0.0
+        PdotP_tot = (lin_domain / Pb) + PdotP_pm + PdotP_gal
+
+        # normalize conv to the PdotP_tot domain
+        conv /= util.QuantitySpline(lin_domain, conv, k=1, s=0, ext=1).integral(
+            -np.inf, np.inf
         )
+
+        prob_dist = util.QuantitySpline(PdotP_tot, conv, k=1, s=0, ext=1)
 
         probs[i] = prob_dist(Pbdot_meas / Pb)
 

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -209,11 +209,11 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         # Set up the equally-spaced linear convolution domain
         # ------------------------------------------------------------------
 
-        # TODO both 5000 and 1e-18 need to be computed dynamically
-        #   5000 to be enough steps to sample the gaussian and int peaks
-        #   1e-18 to be far enough for the int distribution to go to zero
-        #   Both balanced so as to use way too much memory unnecessarily
-        #   Must be symmetric, to avoid bound effects
+        # TODO this hard-coded domain is a bit brittle and would ideally be
+        # dynamically computed from the PdotP_domain returned by
+        # cluster_component. This current setup works for 47 Tuc and
+        # Terzan 5, but if we run into issues with other clusters, we should
+        # revisit this.
 
         # mirrored/starting at zero so very small gaussians become the δ-func
         lin_domain = np.linspace(0., 3e-18, 5_000 // 2)
@@ -225,11 +225,6 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
 
         # TODO if width << Pint width, maybe don't bother with first conv.
 
-        # NOTE: this now uses the lin_domain instead of the PdotP domain
-        # in order to accommodate pulsar X who's error spline was being cut
-        # too soon, giving zero probability to valid regions.
-        # if lin_domain gets dynamically computed in the future, make sure it's
-        # large enough to accommodate pulsar X.
         err = util.gaussian(x=lin_domain, sigma=ΔPdot_meas, mu=0)
 
         # ------------------------------------------------------------------

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -5,7 +5,6 @@ from ..core.data import DEFAULT_THETA, FittableModel
 
 import numpy as np
 import astropy.units as u
-import scipy.interpolate as interp
 
 import logging
 

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -282,7 +282,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         # Interpolate the likelihood value from the overall distribution
         # ------------------------------------------------------------------
 
-        PdotP_tot = (lin_domain / P) + PdotP_pm + PdotP_gal
+        PdotP_tot = ((lin_domain / P) + PdotP_pm + PdotP_gal).to_value(1 / u.s)
 
         # normalize conv2 to the PdotP_tot domain
         conv2 /= util.QuantitySpline(
@@ -484,7 +484,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         # Interpolate the likelihood value from the overall distribution
         # ------------------------------------------------------------------
 
-        PdotP_tot = (lin_domain / Pb) + PdotP_pm + PdotP_gal
+        PdotP_tot = ((lin_domain / Pb) + PdotP_pm + PdotP_gal).to_value(1 / u.s)
 
         # normalize conv to the PdotP_tot domain
         conv /= util.QuantitySpline(PdotP_tot, conv, k=1, s=0, ext=1).integral(

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -157,7 +157,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
                     f"radius {model.rt}")
             logging.debug(mssg)
 
-            return np.NINF
+            return -np.inf
 
         P = pulsars['P'][i].to('s')
 
@@ -196,7 +196,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
             """
             logging.warning(mssg, exc_info=err)
 
-            return np.NINF
+            return -np.inf
 
         Pdot_domain = (P * PdotP_domain).decompose()
 
@@ -306,7 +306,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
     logprobs = np.log(probs)
 
     # Replace NaNs with -inf
-    logprobs[np.isnan(logprobs)] = np.NINF
+    logprobs[np.isnan(logprobs)] = -np.inf
 
     return np.sum(logprobs)
 
@@ -402,7 +402,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
                     f"radius {model.rt}")
             logging.debug(mssg)
 
-            return np.NINF
+            return -np.inf
 
         Pb = pulsars['Pb'][i].to('s')
 
@@ -441,7 +441,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
             """
             logging.warning(mssg, exc_info=err)
 
-            return np.NINF
+            return -np.inf
 
         Pdot_domain = (Pb * PdotP_domain).decompose()
 
@@ -510,7 +510,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
     logprobs = np.log(probs)
 
     # Replace NaNs with -inf
-    logprobs[np.isnan(logprobs)] = np.NINF
+    logprobs[np.isnan(logprobs)] = -np.inf
 
     return np.sum(logprobs)
 

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -201,7 +201,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         Pdot_domain = (P * PdotP_domain).decompose()
 
         # linear to avoid effects around asymptote
-        Pdot_c_spl = interp.UnivariateSpline(
+        Pdot_c_spl = util.QuantitySpline(
             Pdot_domain, PdotP_c_prob, k=1, s=0, ext=1
         )
 
@@ -248,7 +248,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
 
         Pdot_int_prob = Pdot_kde(np.vstack([P_grid, Pdot_int_domain]))
 
-        Pdot_int_spl = interp.UnivariateSpline(
+        Pdot_int_spl = util.QuantitySpline(
             Pdot_int_domain, Pdot_int_prob, k=1, s=0, ext=1
         )
 
@@ -257,7 +257,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
             h=np.log10, h_prime=lambda y: (1 / (np.log(10) * y))
         )
 
-        Pdot_int_spl = interp.UnivariateSpline(
+        Pdot_int_spl = util.QuantitySpline(
             10**Pdot_int_domain, Pdot_int_prob, k=1, s=0, ext=1
         )
 
@@ -270,7 +270,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         conv2 = np.convolve(conv1, Pdot_int_spl(lin_domain), 'same')
 
         # Normalize
-        conv2 /= interp.UnivariateSpline(
+        conv2 /= util.QuantitySpline(
             lin_domain, conv2, k=1, s=0, ext=1
         ).integral(-np.inf, np.inf)
 
@@ -446,7 +446,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         Pdot_domain = (Pb * PdotP_domain).decompose()
 
         # linear to avoid effects around asymptote
-        Pdot_c_spl = interp.UnivariateSpline(
+        Pdot_c_spl = util.QuantitySpline(
             Pdot_domain, PdotP_c_prob, k=1, s=0, ext=1
         )
 
@@ -464,8 +464,6 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
 
         err = util.gaussian(x=lin_domain, sigma=ΔPbdot_meas, mu=0)
 
-        # err_spl = interp.UnivariateSpline(Pdot_domain, err, k=1, s=0, ext=1)
-
         # ------------------------------------------------------------------
         # Convolve the different distributions
         # ------------------------------------------------------------------
@@ -474,9 +472,9 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         conv = np.convolve(err, Pdot_c_spl(lin_domain), 'same')
 
         # Normalize
-        conv /= interp.UnivariateSpline(
-            lin_domain, conv, k=1, s=0, ext=1
-        ).integral(-np.inf, np.inf)
+        conv /= util.QuantitySpline(lin_domain, conv, k=1, s=0, ext=1).integral(
+            -np.inf, np.inf
+        )
 
         # ------------------------------------------------------------------
         # Compute the Shklovskii (proper motion) effect component

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -151,7 +151,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
 
         R = pulsars['r'][i].to(u.pc)
 
-        if R >= model.rt:
+        if model.rt <= R:
 
             mssg = (f"Pulsar {pulsars['id'][i]} is outside cluster truncation "
                     f"radius {model.rt}")
@@ -396,7 +396,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
 
         R = pulsars['r'][i].to(u.pc)
 
-        if R >= model.rt:
+        if model.rt <= R:
 
             mssg = (f"Pulsar {pulsars['id'][i]} is outside cluster truncation "
                     f"radius {model.rt}")

--- a/gcfit/probabilities/pulsars.py
+++ b/gcfit/probabilities/pulsars.py
@@ -406,12 +406,13 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
 
 
 def galactic_component(lat, lon, D):
-    '''Compute the "galactic" component of pulsar Pdot-P (using `gala`)'''
+    """Compute the "galactic" component of pulsar Pdot-P, using the
+    `MilkyWayPotential2022` potential from `gala`."""
     import gala.potential as pot
     from astropy.coordinates import SkyCoord
 
     # Milky Way Potential
-    mw = pot.BovyMWPotential2014()
+    mw = pot.MilkyWayPotential2022()
 
     # Pulsar position in galactocentric coordinates
     crd = SkyCoord(b=lat, l=lon, distance=D, frame='galactic')

--- a/gcfit/probabilities/pulsars.py
+++ b/gcfit/probabilities/pulsars.py
@@ -2,7 +2,6 @@ from ..util import (QuantitySpline, gaussian, div_error, trim_peaks,
                     find_intersections)
 
 import scipy.stats
-import scipy as sp
 import numpy as np
 import astropy.units as u
 from astropy.constants import c

--- a/gcfit/probabilities/pulsars.py
+++ b/gcfit/probabilities/pulsars.py
@@ -134,8 +134,9 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
 
     R = R.to(model.rt.unit)
 
-    if R >= model.rt:
-        raise ValueError(f"Pulsar position outside cluster bound ({model.rt})")
+    if model.rt <= R:
+        msg = f"Pulsar position outside cluster bound ({model.rt})"
+        raise ValueError(msg)
 
     nz = model.nstep
 
@@ -183,10 +184,7 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
     # There are 2 possibilities depending on R:
     # (1) the maximum acceleration occurs within the cluster boundary, or
     # (2) max(a_z) = a_z,t (this happens when R ~ r_t)
-    if len(zmax) > 0:
-        azmax = az_spl(zmax[0])
-    else:
-        azmax = az_spl(z[-1])
+    azmax = az_spl(zmax[0]) if len(zmax) > 0 else az_spl(z[-1])
 
     # Old version here for future reference
     # increment density by 2 order of magnitude smaller than azmax
@@ -320,8 +318,11 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
 
             # If the area is way less than 1, we should just throw an exception
             if norm < 0.9:
-                raise ValueError("Paz failed to integrate to 1.0, too small to"
-                                 f"continue. Area: {norm:.6f}")
+                msg = (
+                    "Paz failed to integrate to 1.0, too small to"
+                    f"continue. Area: {norm:.6f}"
+                )
+                raise ValueError(msg)
 
             # Manual normalization
             Paz_dist /= norm
@@ -365,8 +366,11 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
 
             # If the area is way less than 1, we should just throw an exception
             if norm < 0.9:
-                raise ValueError("Paz failed to integrate to 1.0, too small to"
-                                 f" continue. Area: {norm:.6f}")
+                msg = (
+                    "Paz failed to integrate to 1.0, too small to"
+                    f" continue. Area: {norm:.6f}"
+                )
+                raise ValueError(msg)
 
             # Manual normalization
             Paz_dist /= norm
@@ -452,7 +456,7 @@ def shklovskii_component(pm, D):
 
 
 def field_Pdot_KDE(*, pulsar_db='field_msp.dat'):
-    '''Return a gaussian kde representing the galactic field pulsar P-Pdot.
+    """Return a gaussian kde representing the galactic field pulsar P-Pdot.
 
     Computes a 2D gaussian KDE based on the period and period derivative
     distribution of galactic field millisecond pulsars, which can then be used
@@ -465,7 +469,7 @@ def field_Pdot_KDE(*, pulsar_db='field_msp.dat'):
     This KDE should be pre-constructed (by `valid_likelihoods`), and it is
     unlikely users need to call this function directly.
 
-    Pulsar data is retrieved from the ANTF pulsar catalogue using the
+    Pulsar data is retrieved from the ATNF pulsar catalogue using the
     `psrcat` program. The data can be found in the package resources, and
     can be recreated using the command:
     `psrcat -db_file psrcat.db -c "p0 p1 p1_i GB GL Dist" -l "p0 < 0.1 &&
@@ -482,7 +486,7 @@ def field_Pdot_KDE(*, pulsar_db='field_msp.dat'):
     scipy.stats.gaussian_kde
         The 2D Gaussian KDE representing the intrinsic spin-down distributions
         of galactic field pulsars.
-    '''
+    """
     from ..util.data import _open_resources
 
     # Get field pulsars data

--- a/gcfit/probabilities/pulsars.py
+++ b/gcfit/probabilities/pulsars.py
@@ -501,8 +501,10 @@ def field_Pdot_KDE(*, pulsar_db='field_msp.dat'):
     Pdot_int = Pdot_pm - galactic_component(*(lat, lon), D).value
 
     P = np.log10(P)
-    # TODO would be nice to get rid of the warning that happens here everytime
-    Pdot_int = np.log10(Pdot_int)
+
+    # catch the warning here for the log10
+    with np.errstate(invalid="ignore"):
+        Pdot_int = np.log10(Pdot_int)
 
     # TODO some Pdot_pm < Pdot_gal; this may or may not be physical, need check
     finite = np.isfinite(Pdot_int)

--- a/gcfit/probabilities/pulsars.py
+++ b/gcfit/probabilities/pulsars.py
@@ -202,15 +202,15 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
 
     Δa = np.diff(az_domain)[1]
 
-    # TODO look at the old new_Paz to get the comments for this stuff
-
     if DM is None:
 
         Paz_dist = np.zeros_like(az_domain.value)
         for i, a in enumerate(az_domain):
-
+            # find every z value that has this line-of-sight acceleration
             z_values = find_intersections(az, z, a)
 
+            # probability distribution over acceleration then summed over each
+            # possible z value
             Paz_dist[i] = np.sum(
                 rhoz_spl(z_values).value / np.abs(az_der(z_values).value),
                 axis=0

--- a/gcfit/probabilities/pulsars.py
+++ b/gcfit/probabilities/pulsars.py
@@ -316,7 +316,7 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
             # If the area is way less than 1, we should just throw an exception
             if norm < 0.9:
                 msg = (
-                    "Paz failed to integrate to 1.0, too small to"
+                    "Paz failed to integrate to 1.0, too small to "
                     f"continue. Area: {norm:.6f}"
                 )
                 raise ValueError(msg)
@@ -364,8 +364,8 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
             # If the area is way less than 1, we should just throw an exception
             if norm < 0.9:
                 msg = (
-                    "Paz failed to integrate to 1.0, too small to"
-                    f" continue. Area: {norm:.6f}"
+                    "Paz failed to integrate to 1.0, too small to "
+                    f"continue. Area: {norm:.6f}"
                 )
                 raise ValueError(msg)
 

--- a/gcfit/probabilities/pulsars.py
+++ b/gcfit/probabilities/pulsars.py
@@ -253,9 +253,7 @@ def cluster_component(model, R, mass_bin, DM=None, ΔDM=None, DM_mdata=None, *,
 
         # set up the LOS spline for the DM based Paz
         DM_gaussian = gaussian(x=z_domain, mu=DM_los, sigma=DM_los_err)
-        DM_los_spl = sp.interpolate.UnivariateSpline(
-            x=z_domain, y=DM_gaussian, s=0, k=3, ext=1
-        )
+        DM_los_spl = QuantitySpline(x=z_domain, y=DM_gaussian, s=0, k=3, ext=1)
 
         # We still only want positive values for the other splines
         az_domain = np.abs(az_domain)


### PR DESCRIPTION
Currently, the pulsar likelihoods are normalized as $P(\dot{P})$ rather than $P(\dot{P}/P)$. In effect, this means that each contribution from each pulsar to the total likelihood was weighted by the inverse of its period. This is an especially large effect for the orbital periods whose importance was reduced by several orders of magnitude compared to the spin periods. 

While I made the above fixes, I also switched our Milky Way potential from `BovyMWPotential2014` to `MilkyWayPotential2022`. This potential is fit to more recent data, but most importantly does not depend on `GSL` which was the cause of many installation issues. The differences between these potentials in terms of period derivatives are several orders of magnitude smaller than the effect of the cluster potential. Closes https://github.com/nmdickson/GCfit/issues/46.