### PR TITLE
Hotfix/pulsar domains

### DIFF
--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -208,14 +208,12 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         # Set up the equally-spaced linear convolution domain
         # ------------------------------------------------------------------
 
-        # TODO this hard-coded domain is a bit brittle and would ideally be
-        # dynamically computed from the PdotP_domain returned by
-        # cluster_component. This current setup works for 47 Tuc and
-        # Terzan 5, but if we run into issues with other clusters, we should
-        # revisit this.
+        # Greater of 5σ or 250% past Pdot_c peak, to cover full convolution
+        domain_max = np.max((5 * ΔPdot_meas, 2.5 * np.abs(Pdot_domain).max()))
+
+        lin_domain = np.linspace(0., domain_max, 10_000 // 2)
 
         # mirrored/starting at zero so very small gaussians become the δ-func
-        lin_domain = np.linspace(0., 3e-18, 5_000 // 2)
         lin_domain = np.concatenate((np.flip(-lin_domain[1:]), lin_domain))
 
         # ------------------------------------------------------------------
@@ -262,7 +260,6 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         conv1 = np.convolve(err, Pdot_c_spl(lin_domain), 'same')
 
         conv2 = np.convolve(conv1, Pdot_int_spl(lin_domain), 'same')
-
 
         # ------------------------------------------------------------------
         # Compute the Shklovskii (proper motion) effect component
@@ -448,8 +445,12 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         # Set up the equally-spaced linear convolution domain
         # ------------------------------------------------------------------
 
+        # Greater of 5σ or 250% past Pdot_c peak, to cover full convolution
+        domain_max = np.max((5 * ΔPbdot_meas, 2.5 * np.abs(Pdot_domain).max()))
+
+        lin_domain = np.linspace(0., domain_max, 10_000 // 2)
+
         # mirrored/starting at zero so very small gaussians become the δ-func
-        lin_domain = np.linspace(0., 1e-9, 10_000 // 2)
         lin_domain = np.concatenate((np.flip(-lin_domain[1:]), lin_domain))
 
         # ------------------------------------------------------------------
@@ -464,7 +465,6 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
 
         # conv = np.convolve(err, PdotP_c_prob, 'same')
         conv = np.convolve(err, Pdot_c_spl(lin_domain), 'same')
-
 
         # ------------------------------------------------------------------
         # Compute the Shklovskii (proper motion) effect component

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -211,7 +211,7 @@ def likelihood_pulsar_spin(model, pulsars, Pdot_kde, cluster_μ, coords,
         # Greater of 5σ or 250% past Pdot_c peak, to cover full convolution
         domain_max = np.max((5 * ΔPdot_meas, 2.5 * np.abs(Pdot_domain).max()))
 
-        lin_domain = np.linspace(0., domain_max, 10_000 // 2)
+        lin_domain = np.linspace(0., domain_max, 5_000 // 2)
 
         # mirrored/starting at zero so very small gaussians become the δ-func
         lin_domain = np.concatenate((np.flip(-lin_domain[1:]), lin_domain))
@@ -448,7 +448,7 @@ def likelihood_pulsar_orbital(model, pulsars, cluster_μ, coords, use_DM=False,
         # Greater of 5σ or 250% past Pdot_c peak, to cover full convolution
         domain_max = np.max((5 * ΔPbdot_meas, 2.5 * np.abs(Pdot_domain).max()))
 
-        lin_domain = np.linspace(0., domain_max, 10_000 // 2)
+        lin_domain = np.linspace(0., domain_max, 5_000 // 2)
 
         # mirrored/starting at zero so very small gaussians become the δ-func
         lin_domain = np.concatenate((np.flip(-lin_domain[1:]), lin_domain))

--- a/gcfit/util/units.py
+++ b/gcfit/util/units.py
@@ -151,9 +151,9 @@ class QuantitySpline(scipy.interpolate.UnivariateSpline):
         return res
 
     def derivative(self, n=1):
-        from scipy.interpolate import fitpack
+        from scipy.interpolate import splder
 
-        tck = fitpack.splder(self._eval_args, n)
+        tck = splder(self._eval_args, n)
 
         # if self.ext is 'const', derivative.ext will be 'zeros'
         ext = 1 if self.ext == 3 else self.ext


### PR DESCRIPTION
Changes the linear convolution domain used in pulsar likelihoods to be dynamically computed, rather than hard coded to support the pulsars in 47 Tuc and Ter 5. The new domain reaches up to either 5σ of the Gaussian error term or 250% larger than the peak of the cluster component, whichever is larger. This should be enough to probe all structure in the convolved distributions for both spin and orbital period likelihoods.