### PR TITLE
Feature/agnostic params

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -1,6 +1,6 @@
 from .. import util
 from ..util import mass
-from ..core.data import Observations, FittableModel, FittableEvolvedModel
+from ..core.data import Observations, Model, EvolvedModel
 
 import h5py
 import numpy as np
@@ -21,29 +21,13 @@ __all__ = ['ModelVisualizer', 'CIModelVisualizer', 'ObservationsVisualizer',
            'EvolvedVisualizer', 'SampledVisualizer', 'ModelCollection']
 
 
-def _get_model(theta, observations, *,
-               strict=False, cls=FittableModel,
-               flexible_natal_kicks=False, flexible_IFMR=False, **kwargs):
+def _get_model(theta, model_params, *, strict=False, cls=Model):
     '''Compute a model based on `theta` and optionally fail quietly.'''
 
-    if flexible_natal_kicks or flexible_IFMR:
-        # Assume it's the last N elements in theta (not super robust tbh)
-
-        # bh_lbls = observations.BH_initials.keys()
-        bh_lbls = (
-            (list(observations._kick_initials) if flexible_natal_kicks else [])
-            + (list(observations._IFMR_initials) if flexible_IFMR else [])
-        )
-
-        theta, theta_BH = theta[:-len(bh_lbls)], theta[-len(bh_lbls):]
-
-        _, MF_kwargs = util.pop_flexible_BHs(dict(zip(bh_lbls, theta_BH)),
-                                             flexible_natal_kicks,
-                                             flexible_IFMR)
-        kwargs['MF_kwargs'] = kwargs.get('MF_kwargs', dict()) | MF_kwargs
+    params = model_params.build_args(theta)
 
     try:
-        return cls(theta, observations=observations, **kwargs)
+        return cls(*params.args, **params.kwargs)
 
     except ValueError:
         mssg = f"{cls} did not converge with {theta=}"
@@ -54,9 +38,8 @@ def _get_model(theta, observations, *,
             return None
 
 
-def _get_ev_model(theta, observations, strict=False, **kwargs):
-    return _get_model(theta, observations,
-                      strict=strict, cls=FittableEvolvedModel, **kwargs)
+def _get_ev_model(theta, model_params, strict=False):
+    return _get_model(theta, model_params, strict=strict, cls=EvolvedModel)
 
 
 # --------------------------------------------------------------------------
@@ -3288,7 +3271,7 @@ class ModelVisualizer(_ClusterVisualizer):
     '''
 
     @classmethod
-    def from_chain(cls, chain, observations, method='median', **kwargs):
+    def from_chain(cls, chain, observations, model_params, method='median'):
         '''Initialize a visualizer based on a full chain of parameters.
 
         Classmethod which creates a single model visualizer object based on a
@@ -3300,7 +3283,7 @@ class ModelVisualizer(_ClusterVisualizer):
         ----------
         chain : np.ndarray[..., Nparams]
             Array containing chain of parameters values. Final axis must be
-            of the size of the number of model parameters (13).
+            of the size of the number of model parameters.
 
         observations : gcfit.Observations
             The `Observations` instance corresponding to this cluster.
@@ -3331,11 +3314,10 @@ class ModelVisualizer(_ClusterVisualizer):
 
         theta = reduc_methods[method](chain, axis=0)
 
-        return cls(_get_model(theta, observations, strict=True, **kwargs),
-                   observations)
+        return cls(_get_model(theta, model_params, strict=True), observations)
 
     @classmethod
-    def from_theta(cls, theta, observations, **kwargs):
+    def from_theta(cls, theta, observations, model_params):
         '''Initialize a visualizer based on a single set of parameters.
 
         Classmethod which creates a single model visualizer object based on a
@@ -3360,8 +3342,7 @@ class ModelVisualizer(_ClusterVisualizer):
         --------
         gcfit.FittableModel : Model subclass used to initialize the model.
         '''
-        return cls(_get_model(theta, observations, strict=True, **kwargs),
-                   observations)
+        return cls(_get_model(theta, model_params, strict=True), observations)
 
     def __init__(self, model, observations=None):
         self.model = model
@@ -3903,8 +3884,8 @@ class CIModelVisualizer(_ClusterVisualizer):
         self._model_getter = _get_model
 
     @classmethod
-    def from_chain(cls, chain, observations, N=100, *,
-                   verbose=False, pool=None, **kwargs):
+    def from_chain(cls, chain, observations, model_params, N=100, *,
+                   verbose=False, pool=None):
         '''Initialize a CI visualizer based on a full chain of parameters.
 
         Classmethod which creates a model visualizer object based on a
@@ -3973,7 +3954,7 @@ class CIModelVisualizer(_ClusterVisualizer):
 
         median_chain = np.median(chain, axis=0)
 
-        params = list(viz.obs.initials)
+        params = model_params.free_params
 
         viz.F = median_chain[params.index('F')]
         viz.s2 = median_chain[params.index('s2')]
@@ -3992,8 +3973,8 @@ class CIModelVisualizer(_ClusterVisualizer):
         huge_theta = chain[np.argmax(chain[:, params.index('g')])]
 
         try:
-            huge_model = viz._model_getter(huge_theta, viz.obs,
-                                           strict=True, **kwargs)
+            huge_model = viz._model_getter(huge_theta, model_params,
+                                           strict=True)
         except ValueError as err:
             mssg = f"Base model did not converge with {huge_theta=}"
             raise ValueError(mssg) from err
@@ -4152,8 +4133,8 @@ class CIModelVisualizer(_ClusterVisualizer):
         # Setup iteration and pooling
         # ------------------------------------------------------------------
 
-        get_model = functools.partial(viz._model_getter, observations=viz.obs,
-                                      **kwargs)
+        get_model = functools.partial(viz._model_getter,
+                                      model_params=model_params)
 
         try:
             _map = map if pool is None else pool.imap_unordered
@@ -5058,7 +5039,7 @@ class EvolvedVisualizer(ModelVisualizer):
         return fig
 
     @classmethod
-    def from_chain(cls, chain, observations, method='median', **kwargs):
+    def from_chain(cls, chain, observations, model_params, method='median'):
         '''Initialize a visualizer based on a full chain of parameters.
 
         Classmethod which creates a single model visualizer object based on a
@@ -5101,11 +5082,11 @@ class EvolvedVisualizer(ModelVisualizer):
 
         theta = reduc_methods[method](chain, axis=0)
 
-        return cls(_get_ev_model(theta, observations, strict=True, **kwargs),
+        return cls(_get_ev_model(theta, model_params, strict=True),
                    observations)
 
     @classmethod
-    def from_theta(cls, theta, observations, **kwargs):
+    def from_theta(cls, theta, observations, model_params):
         '''Initialize a visualizer based on a single set of parameters.
 
         Classmethod which creates a single model visualizer object based on a
@@ -5130,7 +5111,7 @@ class EvolvedVisualizer(ModelVisualizer):
         --------
         gcfit.FittableModel : Model subclass used to initialize the model.
         '''
-        return cls(_get_ev_model(theta, observations, strict=True, **kwargs),
+        return cls(_get_ev_model(theta, observations, strict=True),
                    observations)
 
     def __init__(self, model, observations=None):
@@ -5360,7 +5341,7 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
         if verbose_label:
             label = "Initial Half-Mass Density"
         else:
-            label = r'\rho_{\mathrm{h},0}'
+            label = r'$\rho_{\mathrm{h},0}$'
 
         return self._plot_quantity('rhoh0', fig=fig, ax=ax, color=color,
                                    xlabel=label, **kwargs)
@@ -5418,7 +5399,7 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
         self._model_getter = _get_ev_model
 
     @classmethod
-    def from_chain(cls, chain, observations, N=100, *,
+    def from_chain(cls, chain, observations, model_params, N=100, *,
                    verbose=False, pool=None, **kwargs):
 
         import functools
@@ -5439,7 +5420,7 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
 
         median_chain = np.median(chain, axis=0)
 
-        params = list(viz.obs.ev_initials)
+        params = model_params.free_params
 
         viz.F = median_chain[params.index('F')]
         viz.s2 = median_chain[params.index('s2')]
@@ -5456,7 +5437,7 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
         # or plots
 
         huge_theta = chain[np.argmax(chain[:, params.index('g')])]
-        huge_model = viz._model_getter(huge_theta, viz.obs, **kwargs)
+        huge_model = viz._model_getter(huge_theta, model_params)
 
         if huge_model is None:
             raise ValueError(f"Base model did not converge with {huge_theta=}")
@@ -5614,8 +5595,8 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
         # Setup iteration and pooling
         # ------------------------------------------------------------------
 
-        get_model = functools.partial(viz._model_getter, observations=viz.obs,
-                                      **kwargs)
+        get_model = functools.partial(viz._model_getter,
+                                      model_params=model_params)
 
         try:
             _map = map if pool is None else pool.imap_unordered
@@ -5914,16 +5895,21 @@ class ObservationsVisualizer(_ClusterVisualizer):
 
                 self.mass_func[key].append(this_slc)
 
-    def __init__(self, observations, d=None):
+    def __init__(self, observations, rh=None, d=None):
         self.obs = observations
         self.name = observations.cluster
-
-        self.rh = observations.initials['rh'] << u.pc
 
         self.star_bin = None
         self.mj = [] << u.Msun
 
-        self.d = (d or observations.initials['d']) << u.kpc
+        try:
+            self.rh = (rh or observations.initials['rh']) << u.pc
+            self.d = (d or observations.initials['d']) << u.kpc
+        except KeyError:
+            mssg = ("Must either supply both rh and d, or have them stored "
+                    "in observations.initials")
+            raise ValueError(mssg)
+
         self.s2 = 0.
         self.F = 1.
 
@@ -6390,8 +6376,8 @@ class ModelCollection:
         return cls([model_cls(m, o) for m, o in zip(models, obs_list)])
 
     @classmethod
-    def from_chains(cls, chains, obs_list, ci=True, evolved=False,
-                    model_kws=None, **kwargs):
+    def from_chains(cls, chains, obs_list, prms_list,
+                    ci=True, evolved=False, **kwargs):
         '''Initialize from a collection of parameter chains.
 
         Initializes a `ModelCollection` instance of either `ModelVisualizer` or
@@ -6428,14 +6414,11 @@ class ModelCollection:
         if obs_list is None:
             obs_list = [None, ] * chains.shape[0]
 
-        if model_kws is None:
-            model_kws = [dict(), ] * chains.shape[0]
-
         if isinstance(evolved, bool):
             evolved = [evolved, ] * chains.shape[0]
 
         visualizers = []
-        for ch, obs, ev, mkw in zip(chains, obs_list, evolved, model_kws):
+        for ch, obs, ev, mprm in zip(chains, obs_list, evolved, prms_list):
 
             if ev:
                 viz = CIEvolvedVisualizer if ci else EvolvedVisualizer
@@ -6446,7 +6429,7 @@ class ModelCollection:
 
             init = viz.from_chain if ch.ndim == 2 else viz.from_theta
 
-            visualizers.append(init(ch[...], obs, **mkw, **kwargs))
+            visualizers.append(init(ch[...], obs, mprm, **kwargs))
 
         return cls(visualizers)
 

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -5111,7 +5111,7 @@ class EvolvedVisualizer(ModelVisualizer):
         --------
         gcfit.FittableModel : Model subclass used to initialize the model.
         '''
-        return cls(_get_ev_model(theta, observations, strict=True),
+        return cls(_get_ev_model(theta, model_params, strict=True),
                    observations)
 
     def __init__(self, model, observations=None):

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -594,7 +594,8 @@ class _SingleRunAnalysis(_RunAnalysis):
 
             # Load free parameters in a backwards compatible way
             try:
-                free_params = tuple(fp.decode() for fp in mdata['free_params'])
+                free_params = tuple(fp.decode()
+                                    for fp in file['metadata/free_params'])
 
                 # If any transforms stored, use those (and assume nothing else)
                 # TODO currently can only support sympy-style transforms
@@ -871,8 +872,7 @@ class MCMCRun(_SingleRunAnalysis):
                 except KeyError:
                     continue
 
-        prior_kwargs = {'model_params': self._modelparams, 'err_on_fail': False,
-                        'evolved': self._evolved}
+        prior_kwargs = {'model_params': self._modelparams, 'err_on_fail': False}
 
         return priors.Priors(prior_params, **prior_kwargs)
 

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -5180,20 +5180,20 @@ class RunCollection(_RunAnalysis):
         if params is None:
 
             # assume runs are all of same flavour
-            params = self.runs[0]._get_labels(label_fixed=False)
+            params = self.runs[0]._get_labels()
 
             if log_radii:
                 params = [f'log_{p}' if p.startswith('rh') else p
                           for p in params]
 
             if include_FeH:
-                params += ['FeH']
+                params += ('FeH',)
 
             if include_BH:
-                params += ['M_BH']
+                params += ('M_BH',)
 
             if include_rt:
-                params += ['log_rt' if log_radii else 'rt']
+                params += ('log_rt' if log_radii else 'rt',)
 
         # setup axes
         Nparams = len(params)
@@ -5300,13 +5300,13 @@ class RunCollection(_RunAnalysis):
             labels = self.runs[0]._get_labels()
 
         else:
-            labels = params
+            labels = tuple(params)
 
         if include_FeH:
-            labels = ['FeH'] + labels
+            labels = ('FeH',) + labels
 
         if include_BH:
-            labels += ['M_BH', 'N_BH', 'f_BH', 'f_rem']
+            labels += ('M_BH', 'N_BH', 'f_BH', 'f_rem')
 
         # Fill in a dictionary of column data
 

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -1,6 +1,7 @@
-from .. import Observations
+from .. import Observations, DEFAULT_FREE_PARAMS, DEFAULT_FREE_EV_PARAMS
 from ..probabilities import priors
 from ..core.main import MCMCFittingState, NestedFittingState
+from ..util.probabilities import ModelParameters
 from .models import CIModelVisualizer, ModelVisualizer
 from .models import EvolvedVisualizer, CIEvolvedVisualizer
 from .models import ModelCollection
@@ -450,6 +451,7 @@ class _RunAnalysis:
 
 
 # TODO a way to plot our priors, probably for both vizs
+# TODO some things in this shared base class are only valid for NestedRun
 class _SingleRunAnalysis(_RunAnalysis):
     '''Base class for all visualizers of single runs, of all types.
 
@@ -489,7 +491,7 @@ class _SingleRunAnalysis(_RunAnalysis):
 
         if value is not None:
 
-            _, ch = self._get_chains(include_fixed=False, apply_mask=False)
+            _, ch = self._get_chains(apply_mask=False)
 
             # flatten chain if necessary (to work with MCMC, mask must be flat)
             if ch.ndim > 2:
@@ -590,13 +592,38 @@ class _SingleRunAnalysis(_RunAnalysis):
             # Check if this is an evolved modelling fit or not
             self._evolved = mdata.get('evolved', False)
 
-            # Check if this had extra flexible BH parameters
-            self._free_kicks = mdata.get('flexible_natal_kicks', False)
-            self._free_IFMR = mdata.get('flexible_IFMR', False)
+            # Load free parameters in a backwards compatible way
+            try:
+                free_params = tuple(fp.decode() for fp in mdata['free_params'])
 
-            # Check for backwards compatibility with old, free BHs
-            if mdata.get('flexible_BHs', False):
-                self._free_kicks = self._free_IFMR = True
+                # If any transforms stored, use those (and assume nothing else)
+                # TODO currently can only support sympy-style transforms
+                if 'param_transforms' in mdata:
+                    transforms = dict(mdata['param_transforms'].attrs)
+                    compatibility_transforms = False
+                else:
+                    transforms = None
+                    compatibility_transforms = True
+
+            except KeyError:
+                free_params = (DEFAULT_FREE_EV_PARAMS if self._evolved
+                               else DEFAULT_FREE_PARAMS)
+
+                if 'fixed_params' in file['metadata']:
+                    free_params = tuple(
+                        fp for fp in free_params
+                        if fp not in file['metadata']['fixed_params'].attrs
+                    )
+
+                # This is an old run, can assume these typical transforms
+                transforms = None
+                compatibility_transforms = True
+
+            # backwards compatibility with old --free-kicks
+            if mdata.get('flexible_natal_kicks', False):
+                free_params += ('kick_slope', 'kick_scale')
+
+            self._parameters = free_params
 
             # Check if this run seems to have used a local cluster data file
             restrict_to = mdata.get('restrict_to', None)
@@ -619,14 +646,11 @@ class _SingleRunAnalysis(_RunAnalysis):
                 mssg = "No cluster name in metadata, must supply observations"
                 raise ValueError(mssg) from err
 
-        self._parameters = list(self.obs.initials if not self._evolved
-                                else self.obs.ev_initials)
-
-        if self._free_kicks:
-            self._parameters += list(self.obs._kick_initials)
-
-        if self._free_IFMR:
-            self._parameters += list(self.obs._IFMR_initials)
+        self._modelparams = ModelParameters(
+            self._parameters, self._get_model_kwargs(),
+            self.obs, self._evolved, transforms=transforms,
+            compatibility_transforms=compatibility_transforms
+        )
 
     @contextlib.contextmanager
     def _openfile(self, group=None, mode='r'):
@@ -643,29 +667,17 @@ class _SingleRunAnalysis(_RunAnalysis):
         finally:
             file.close()
 
-    def _get_labels(self, label_fixed=True, math_labels=False):
+    def _get_labels(self, math_labels=False):
         '''Retrieve labels for all parameters.'''
 
-        labels = self._parameters.copy()
+        labels = self._parameters
 
         if math_labels:
             labels = [_get_latex_label(lbl, with_units=True) for lbl in labels]
 
-        if label_fixed:
-
-            with self._openfile('metadata') as mdata:
-
-                fixed = sorted(
-                    ((k, labels.index(k)) for k in mdata['fixed_params'].attrs),
-                    key=lambda item: labels.index(item[0])
-                )
-
-            for k, i in fixed:
-                labels[i] += ' (fixed)'
-
         return labels
 
-    def _get_model_kwargs(self, note_flexible_BHs=False):
+    def _get_model_kwargs(self):
         '''Return the `model_kwargs` metadata (backwards compatible)'''
 
         def _gather_attrs(key, grp):
@@ -680,13 +692,6 @@ class _SingleRunAnalysis(_RunAnalysis):
                 mdata['model_kwargs'].visititems(_gather_attrs)
             except KeyError:
                 model_kw = {}
-
-        # this is not for `Model`, but for some preliminary stuff (`_get_model`)
-        if note_flexible_BHs:
-            if self._free_kicks:
-                model_kw['flexible_natal_kicks'] = True
-            if self._free_IFMR:
-                model_kw['flexible_IFMR'] = True
 
         return model_kw
 
@@ -836,21 +841,9 @@ class MCMCRun(_SingleRunAnalysis):
 
         with self._openfile() as file:
 
-            labels = self._parameters.copy()
+            labels = self._parameters
 
             chain = self._reduce(file[self._gname]['chain'])
-
-            # Handle fixed parameters
-
-            fixed = sorted(
-                ((k, v, labels.index(k)) for k, v in
-                 file['metadata']['fixed_params'].attrs.items()),
-                key=lambda item: labels.index(item[0])
-            )
-
-            for k, v, i in fixed:
-                labels[i] += ' (fixed)'
-                chain = np.insert(chain, i, v, axis=-1)
 
         if flatten:
             chain = chain.reshape((-1, chain.shape[-1]))
@@ -863,7 +856,6 @@ class MCMCRun(_SingleRunAnalysis):
         with self._openfile('metadata') as mdata:
 
             stored_priors = mdata['specified_priors']
-            fixed = dict(mdata['fixed_params'].attrs)
 
             prior_params = {}
 
@@ -879,11 +871,8 @@ class MCMCRun(_SingleRunAnalysis):
                 except KeyError:
                     continue
 
-        prior_kwargs = {
-            'fixed_initials': fixed, 'err_on_fail': False,
-            'evolved': self._evolved, 'flexible_natal_kicks': self._free_kicks,
-            'flexible_IFMR': self._free_IFMR
-        }
+        prior_kwargs = {'model_params': self._modelparams, 'err_on_fail': False,
+                        'evolved': self._evolved}
 
         return priors.Priors(prior_params, **prior_kwargs)
 
@@ -909,13 +898,12 @@ class MCMCRun(_SingleRunAnalysis):
             The created model visualization object.
         '''
 
-        labels, chain = self._get_chains()
+        _, chain = self._get_chains()
 
-        model_cls = ModelVisualizer if not self.evolved else EvolvedVisualizer
+        model_cls = ModelVisualizer if not self._evolved else EvolvedVisualizer
 
-        model_kw = self._get_model_kwargs(note_flexible_BHs=True)
-
-        return model_cls.from_chain(chain, self.obs, method, **model_kw)
+        return model_cls.from_chain(chain, self.obs, self._modelparams,
+                                    method=method)
 
     def get_CImodel(self, N=100, Nprocesses=1, load=False):
         '''Return a `CIModelVisualizer` instance corresponding to this run.
@@ -946,20 +934,18 @@ class MCMCRun(_SingleRunAnalysis):
         '''
         import multiprocess
 
-        viz_cls = CIModelVisualizer if not self.evolved else CIEvolvedVisualizer
+        viz_cls = CIEvolvedVisualizer if self._evolved else CIModelVisualizer
 
         if load:
             return viz_cls.load(self._filename, observations=self.obs)
 
         else:
 
-            labels, chain = self._get_chains()
-
-            model_kw = self._get_model_kwargs(note_flexible_BHs=True)
+            _, chain = self._get_chains()
 
             with multiprocess.Pool(processes=Nprocesses) as pool:
-                return viz_cls.from_chain(chain, self.obs, N,
-                                          pool=pool, **model_kw)
+                return viz_cls.from_chain(chain, self.obs, self._modelparams,
+                                          N, pool=pool)
 
     # ----------------------------------------------------------------------
     # Plots
@@ -1293,12 +1279,12 @@ class MCMCRun(_SingleRunAnalysis):
         fig, ax = self._setup_multi_artist(fig, shape=None,
                                            constrained_layout=False)
 
-        labels = self._get_labels(math_labels=True, label_fixed=False)
+        labels = self._get_labels(math_labels=True)
         _, chain = self._get_chains()
 
         # params is None or a list of string labels
         if params is not None:
-            raw_labels = self._get_labels(math_labels=False, label_fixed=False)
+            raw_labels = self._get_labels(math_labels=False)
             prm_inds = [raw_labels.index(p) for p in params]
 
             labels = [labels[i] for i in prm_inds]
@@ -1306,16 +1292,10 @@ class MCMCRun(_SingleRunAnalysis):
 
         chain = chain.reshape((-1, chain.shape[-1]))
 
-        # ugly
-        ranges = [1. if 'fixed' not in lbl
-                  else (chain[0, i] - 1, chain[0, i] + 1)
-                  for i, lbl in enumerate(labels)]
-
         corner_kw.setdefault('plot_datapoints', False)
         corner_kw.setdefault('labelpad', 0.25)
 
-        fig = corner.corner(chain, labels=labels, fig=fig,
-                            range=ranges, **corner_kw)
+        fig = corner.corner(chain, labels=labels, fig=fig, **corner_kw)
 
         fig.subplots_adjust(left=0.05, bottom=0.06)
 
@@ -1544,13 +1524,9 @@ class MCMCRun(_SingleRunAnalysis):
 
             for ind, param in enumerate(labels):
 
-                if 'fixed' in param:
-                    mssg += (f'{param[:-8]:>5} = {p50[ind]:.3f} '
-                             f'({"fixed":^14})\n')
-                else:
-                    mssg += (f'{param:>5} = {p50[ind]:.3f} '
-                             f'(+{uncert_plus[ind]:.3f}, '
-                             f'-{uncert_minus[ind]:.3f})\n')
+                mssg += (f'{param:>5} = {p50[ind]:.3f} '
+                         f'(+{uncert_plus[ind]:.3f}, '
+                         f'-{uncert_minus[ind]:.3f})\n')
 
         if content == 'all' or content == 'metadata':
 
@@ -1570,14 +1546,6 @@ class MCMCRun(_SingleRunAnalysis):
                 mssg += f'Dimensions = ({Nwalkers}, {Ndim})\n'
 
                 mdata = file['metadata']
-
-                mssg += 'Fixed parameters:\n'
-                fixed = mdata['fixed_params'].attrs
-                if fixed:
-                    for k, v in fixed.items():
-                        mssg += f'    {k} = {v}\n'
-                else:
-                    mssg += '    None\n'
 
                 mssg += 'Excluded components:\n'
                 exc = mdata['excluded_likelihoods']
@@ -1662,7 +1630,7 @@ class NestedRun(_SingleRunAnalysis):
             N = sum([self.obs[comp[0]].size for comp in
                      self.obs.filter_likelihoods(exc, True)])
 
-            k = len(self._get_chains(include_fixed=False)[1])
+            k = len(self._get_chains()[1])
             lnL0 = np.max(file[self._gname]['logl'][:])
 
         AIC = -2 * lnL0 + (2 * k) + ((2 * k * (k + 1)) / (N - k - 1))
@@ -1680,7 +1648,7 @@ class NestedRun(_SingleRunAnalysis):
             N = sum([self.obs[comp[0]].size for comp in
                      self.obs.filter_likelihoods(exc, True)])
 
-            k = len(self._get_chains(include_fixed=False)[1])
+            k = len(self._get_chains()[1])
             lnL0 = np.max(file[self._gname]['logl'][:])
 
         BIC = -2 * lnL0 + (k * np.log(N))
@@ -1741,20 +1709,6 @@ class NestedRun(_SingleRunAnalysis):
 
                 r[k] = d
 
-            # add in any fixed params, if they exist
-
-            labels = self._get_labels(False, False)
-
-            fixed = sorted(
-                ((k, v, labels.index(k)) for k, v in
-                 file['metadata']['fixed_params'].attrs.items()),
-                key=lambda item: labels.index(item[0])
-            )
-
-            for k, v, i in fixed:
-                r['samples'] = np.insert(r['samples'], i, v, axis=-1)
-                r['samples_u'] = np.insert(r['samples_u'], i, v, axis=-1)
-
         if finite_only:
             # remove the amount of non-finite values we removed from niter
             r['niter'] -= (r['niter'] - r['logl'].size)
@@ -1813,7 +1767,7 @@ class NestedRun(_SingleRunAnalysis):
         return bnds
 
     # TODO some ways of handling and plotting initial_batch only clusters
-    def _get_chains(self, include_fixed=True, *, apply_mask=True):
+    def _get_chains(self, *, apply_mask=True):
         '''Get the "chains" of all samples from this nested sampling run.'''
 
         with self._openfile() as file:
@@ -1823,25 +1777,11 @@ class NestedRun(_SingleRunAnalysis):
             if apply_mask and self.mask is not None:
                 chain = chain[self.mask, :]
 
-            labels = self._parameters.copy()
-
-            fixed = sorted(
-                ((k, v, labels.index(k)) for k, v in
-                 file['metadata']['fixed_params'].attrs.items()),
-                key=lambda item: labels.index(item[0])
-            )
-
-            if include_fixed:
-                for k, v, i in fixed:
-                    labels[i] += ' (fixed)'
-                    chain = np.insert(chain, i, v, axis=-1)
-            else:
-                for *_, i in reversed(fixed):
-                    del labels[i]
+            labels = self._parameters
 
         return labels, chain
 
-    def _get_equal_weight_chains(self, include_fixed=True, add_errors=False, *,
+    def _get_equal_weight_chains(self, add_errors=False, *,
                                  apply_mask=True):
         '''Get the "chains" of samples resampled to be equally weighted.'''
 
@@ -1863,22 +1803,7 @@ class NestedRun(_SingleRunAnalysis):
                 sim_wt = weight_function(sim_run, {'pfrac': 1.}, True)[1][2]
                 eq_chain = resample_equal(sim_run.samples, sim_wt)
 
-            labels = self._parameters.copy()
-
-            fixed = sorted(
-                ((k, v, labels.index(k)) for k, v in
-                 file['metadata']['fixed_params'].attrs.items()),
-                key=lambda item: labels.index(item[0])
-            )
-
-            # TODO allow including fixed without labelling as fixed
-            if include_fixed:
-                for k, v, i in fixed:
-                    labels[i] += ' (fixed)'
-                    eq_chain = np.insert(eq_chain, i, v, axis=-1)
-            else:
-                for *_, i in reversed(fixed):
-                    del labels[i]
+            labels = self._parameters
 
         return labels, eq_chain
 
@@ -1888,7 +1813,6 @@ class NestedRun(_SingleRunAnalysis):
         with self._openfile('metadata') as mdata:
 
             stored_priors = mdata['specified_priors']
-            fixed = dict(mdata['fixed_params'].attrs)
 
             prior_params = {}
 
@@ -1904,11 +1828,8 @@ class NestedRun(_SingleRunAnalysis):
                 except KeyError:
                     continue
 
-        prior_kwargs = {
-            'fixed_initials': fixed, 'err_on_fail': False,
-            'evolved': self._evolved, 'flexible_natal_kicks': self._free_kicks,
-            'flexible_IFMR': self._free_IFMR
-        }
+        prior_kwargs = {'model_params': self._modelparams, 'err_on_fail': False,
+                        'evolved': self._evolved}
 
         return priors.PriorTransforms(prior_params, **prior_kwargs)
 
@@ -1941,15 +1862,14 @@ class NestedRun(_SingleRunAnalysis):
 
         model_cls = ModelVisualizer if not self._evolved else EvolvedVisualizer
 
-        model_kw = self._get_model_kwargs(note_flexible_BHs=True)
-
         if method == 'mean':
             theta = self.parameter_means()[0]
-            return model_cls.from_theta(theta, self.obs, **model_kw)
+            return model_cls.from_theta(theta, self.obs, self._modelparams)
 
         else:
-            labels, chain = self._get_equal_weight_chains(add_errors=add_errors)
-            return model_cls.from_chain(chain, self.obs, method, **model_kw)
+            _, chain = self._get_equal_weight_chains(add_errors=add_errors)
+            return model_cls.from_chain(chain, self.obs, self._modelparams,
+                                        method=method)
 
     def get_CImodel(self, N=100, Nprocesses=1, add_errors=False, shuffle=True,
                     load=False):
@@ -1998,16 +1918,14 @@ class NestedRun(_SingleRunAnalysis):
             return ci_cls.load(self._filename, observations=self.obs)
 
         else:
-            labels, chain = self._get_equal_weight_chains(add_errors=add_errors)
+            _, chain = self._get_equal_weight_chains(add_errors=add_errors)
 
             if shuffle:
                 np.random.default_rng().shuffle(chain, axis=0)
 
-            model_kw = self._get_model_kwargs(note_flexible_BHs=True)
-
             with multiprocess.Pool(processes=Nprocesses) as pool:
-                return ci_cls.from_chain(chain, self.obs, N,
-                                         pool=pool, **model_kw)
+                return ci_cls.from_chain(chain, self.obs, self._modelparams,
+                                         N, pool=pool)
 
     # ----------------------------------------------------------------------
     # Plots
@@ -2052,7 +1970,7 @@ class NestedRun(_SingleRunAnalysis):
         fig, ax = self._setup_multi_artist(fig, shape=None,
                                            constrained_layout=False)
 
-        labels = self._get_labels(math_labels=True, label_fixed=False)
+        labels = self._get_labels(math_labels=True)
 
         if full_volume:
             _, chain = self._get_chains()
@@ -2061,7 +1979,7 @@ class NestedRun(_SingleRunAnalysis):
 
         # params is None or a list of string labels
         if params is not None:
-            raw_labels = self._get_labels(math_labels=False, label_fixed=False)
+            raw_labels = self._get_labels(math_labels=False)
             prm_inds = [raw_labels.index(p) for p in params]
 
             labels = [labels[i] for i in prm_inds]
@@ -2069,16 +1987,10 @@ class NestedRun(_SingleRunAnalysis):
 
         chain = chain.reshape((-1, chain.shape[-1]))
 
-        # ugly
-        ranges = [1. if 'fixed' not in lbl
-                  else (chain[0, i] - 1, chain[0, i] + 1)
-                  for i, lbl in enumerate(labels)]
-
         corner_kw.setdefault('plot_datapoints', False)
         corner_kw.setdefault('labelpad', 0.25)
 
-        fig = corner.corner(chain, labels=labels, fig=fig,
-                            range=ranges, **corner_kw)
+        fig = corner.corner(chain, labels=labels, fig=fig, **corner_kw)
 
         fig.subplots_adjust(left=0.05, bottom=0.06)
 
@@ -2140,7 +2052,7 @@ class NestedRun(_SingleRunAnalysis):
 
         clr = kw.pop('color', None)
 
-        labels, _ = self._get_chains(include_fixed=False)
+        labels, _ = self._get_chains()
 
         try:
             N = len(iteration)
@@ -2916,7 +2828,7 @@ class NestedRun(_SingleRunAnalysis):
             imf[m < 0.08] = m[m < 0.08]**-0.3
             return imf
 
-        def this_imf(m, perc=50):
+        def this_imf(m, perc=50.):
             '''perc is percentile of alpha chain to use'''
 
             ch = self._get_equal_weight_chains()[1]
@@ -3103,7 +3015,7 @@ class NestedRun(_SingleRunAnalysis):
     # Summaries
     # ----------------------------------------------------------------------
 
-    def parameter_summary(self, *, N_simruns=100, label_fixed=False):
+    def parameter_summary(self, *, N_simruns=100):
         '''Compute the mean and std.dev. on each parameter.
 
         Computes and returns a dictionary with the mean and standard deviation
@@ -3127,7 +3039,7 @@ class NestedRun(_SingleRunAnalysis):
             deviations.
         '''
 
-        labels = self._get_labels(label_fixed=label_fixed)
+        labels = self._get_labels()
 
         sr = self._sim_errors(N_simruns)
         mns, _ = self.parameter_means(sim_runs=sr, return_samples=False)
@@ -3189,14 +3101,9 @@ class NestedRun(_SingleRunAnalysis):
 
                 logging.debug(f"---> ({ind}) {param} {mns[ind]}")
 
-                if 'fixed' in param:
-                    mssg += (f'{param[:-8]:>5} = {mns[ind]:.3f} '
-                             f'({"fixed":^14}) | ')
-                    mssg += f'{"-" * 14}\n'
-                else:
-                    mssg += (f'{param:>5} = {mns[ind]:.3f} '
-                             f'(±{σ_mns[ind]:.3f}) | ')
-                    mssg += (f'{std[ind]:.3f} (±{σ_std[ind]:.3f})\n')
+                mssg += (f'{param:>5} = {mns[ind]:.3f} '
+                         f'(±{σ_mns[ind]:.3f}) | ')
+                mssg += (f'{std[ind]:.3f} (±{σ_std[ind]:.3f})\n')
 
         if content == 'all' or content == 'setup':
 
@@ -3205,14 +3112,6 @@ class NestedRun(_SingleRunAnalysis):
             mssg += f'\n{"=" * 9}\n'
 
             with self._openfile('metadata') as mdata:
-
-                mssg += 'Fixed parameters:\n'
-                fixed = mdata['fixed_params'].attrs
-                if fixed:
-                    for k, v in fixed.items():
-                        mssg += f'    {k} = {v}\n'
-                else:
-                    mssg += '    None\n'
 
                 mssg += 'Excluded components:\n'
                 exc = mdata['excluded_likelihoods']
@@ -3579,7 +3478,8 @@ class RunCollection(_RunAnalysis):
 
         self.runs = runs
 
-        labels = runs[0]._get_labels(label_fixed=False)
+        # TODO assumes all runs have same free params, obviously not foolproof
+        labels = runs[0]._get_labels()
 
         # TODO this `equal_weights...` breaks when using MCMCRun's
         self._params = [dict(zip(labels, r._get_equal_weight_chains()[1].T))
@@ -3766,7 +3666,7 @@ class RunCollection(_RunAnalysis):
 
     def _update(self):
         '''Quickly update all run params, in case something has changed.'''
-        labels = self.runs[0]._get_labels(label_fixed=False)
+        labels = self.runs[0]._get_labels()
         self._params = [dict(zip(labels, r._get_equal_weight_chains()[1].T))
                         for r in self.runs]
 
@@ -3814,6 +3714,7 @@ class RunCollection(_RunAnalysis):
                     self.get_CImodels(load=True, **kwargs)
 
                 except RuntimeError:
+                    logging.debug('No saved CI models found, getting models')
                     self.get_models(**kwargs)
 
         data = getattr(self.models, param)
@@ -4102,12 +4003,10 @@ class RunCollection(_RunAnalysis):
 
         obs_list = [run.obs for run in self.runs]
         ev_list = [run._evolved for run in self.runs]
-        kw_list = [run._get_model_kwargs(note_flexible_BHs=True)
-                   for run in self.runs]
+        prm_list = [run._modelparams for run in self.runs]
 
-        mc = ModelCollection.from_chains(chains, obs_list, ci=False,
-                                         evolved=ev_list, model_kws=kw_list,
-                                         **kwargs)
+        mc = ModelCollection.from_chains(chains, obs_list, prm_list, ci=False,
+                                         evolved=ev_list)
 
         # save a copy of models here
         self.models = mc
@@ -4166,7 +4065,7 @@ class RunCollection(_RunAnalysis):
 
         else:
             chains = []
-            kw_list = []
+            prm_list = []
 
             for run in self.runs:
                 _, ch = run._get_equal_weight_chains(add_errors=add_errors)
@@ -4175,13 +4074,13 @@ class RunCollection(_RunAnalysis):
                     np.random.default_rng().shuffle(ch, axis=0)
 
                 chains.append(ch)
-                kw_list.append(run._get_model_kwargs(note_flexible_BHs=True))
+                prm_list.append(run._modelparams)
 
             with multiprocess.Pool(processes=Nprocesses) as pool:
 
-                mc = ModelCollection.from_chains(chains, obs_list, ci=True, N=N,
-                                                 pool=pool, evolved=ev_list,
-                                                 model_kws=kw_list)
+                mc = ModelCollection.from_chains(chains, obs_list, prm_list,
+                                                 ci=True, N=N, pool=pool,
+                                                 evolved=ev_list)
 
         # save a copy of models here
         self.models = mc
@@ -5398,7 +5297,7 @@ class RunCollection(_RunAnalysis):
         # Get name of all desired parameters
 
         if params == 'all':
-            labels = self.runs[0]._get_labels(label_fixed=False)
+            labels = self.runs[0]._get_labels()
 
         else:
             labels = params

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1737,15 +1737,13 @@ class EvolvedModel(Model):
 
         cbh_kwargs = {} if cbh_kwargs is None else cbh_kwargs.copy()
 
-        if MF_kwargs is not None:
+        cbh_kwargs.setdefault('kick', natal_kicks)
 
-            # Try to get some flexible BH params from MF_kwargs for the ibh
-            bhkws = {'kick_method', 'kick_slope', 'kick_scale',
-                     'BH_IFMR_method', 'BH_IFMR_kwargs'}
-            ibh_kwargs = {k: MF_kwargs[k] for k in (MF_kwargs.keys() & bhkws)}
+        ibh_kwargs = dict(kick_method=kick_method, kick_vdisp=kick_vdisp,
+                          kick_slope=kick_slope, kick_scale=kick_scale)
 
-            # Don't overwrite if given explicitly
-            cbh_kwargs.setdefault('ibh_kwargs', ibh_kwargs)
+        # Don't overwrite if given explicitly
+        cbh_kwargs.setdefault('ibh_kwargs', ibh_kwargs)
 
         m_breaks <<= u.Msun
         a_slopes = [-a1, -a2, -a3]

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -981,7 +981,8 @@ class Model(lp.limepy):
     '''
 
     def _evolve_mf(self, m_breaks, a1, a2, a3, nbins, FeH, age, esc_rate, tcc,
-                   NS_ret, BH_ret_int, BHret, natal_kicks, vesc, **kwargs):
+                   NS_ret, BH_ret_int, BHret, natal_kicks, vesc,
+                   kick_method, kick_vdisp,  kick_slope,  kick_scale, **kwargs):
         '''Compute an evolved mass function using `ssptools.EvolvedMF`'''
 
         self._imf = masses.PowerLawIMF(
@@ -1000,6 +1001,10 @@ class Model(lp.limepy):
             BH_ret_dyn=BHret / 100.,
             natal_kicks=natal_kicks,
             vesc=vesc.value,
+            kick_method=kick_method,
+            kick_vdisp=kick_vdisp,
+            kick_slope=kick_slope,
+            kick_scale=kick_scale,
             **kwargs  # will error here if MF_kwargs included any of above args
         )
 
@@ -1084,8 +1089,10 @@ class Model(lp.limepy):
                  s2=0., F=1., *, observations=None, age=None, FeH=None,
                  m_breaks=[0.1, 0.5, 1.0, 100], nbins=[5, 5, 20],
                  tracer_masses=None, tcc=0.0, NS_ret=0.1, BH_ret_int=1.0,
-                 esc_rate=0.0, natal_kicks=True, vesc=90, MF_kwargs=None,
-                 meanmassdef='global', ode_maxstep=1e10, ode_rtol=1e-7):
+                 esc_rate=0.0, natal_kicks=True, kick_method='maxwellian',
+                 vesc=90, kick_vdisp=265., kick_slope=1, kick_scale=20,
+                 MF_kwargs=None, meanmassdef='global',
+                 ode_maxstep=1e10, ode_rtol=1e-7):
 
         # ------------------------------------------------------------------
         # Add/convert units of some quantities. Supports quantities as inputs
@@ -1156,7 +1163,9 @@ class Model(lp.limepy):
         self._mf = self._evolve_mf(m_breaks, a1, a2, a3, nbins,
                                    FeH, age, esc_rate, tcc,
                                    NS_ret, BH_ret_int, BHret,
-                                   natal_kicks, self.vesc0, **MF_kwargs)
+                                   natal_kicks, self.vesc0,
+                                   kick_method, kick_vdisp,
+                                   kick_slope,  kick_scale, **MF_kwargs)
 
         if not self._mf.converged:
             mssg = ("Mass function evolution ODE failed to converge"
@@ -1679,7 +1688,8 @@ class EvolvedModel(Model):
     '''
 
     def _evolve_mf(self, m_breaks, a1, a2, a3, nbins, FeH, age, esc_rate, tcc,
-                   NS_ret, BH_ret_int, BHret, natal_kicks, vesc, **kwargs):
+                   NS_ret, BH_ret_int, BHret, natal_kicks, vesc,
+                   kick_method, kick_vdisp,  kick_slope,  kick_scale, **kwargs):
         '''Alternative MF init using prior-computed IMF and clusterBH outputs'''
         from ssptools import EvolvedMFWithBH
 
@@ -1698,6 +1708,10 @@ class EvolvedModel(Model):
             vesc=vesc.value,
             esc_norm='M',
             md=self.md,
+            kick_method=kick_method,
+            kick_vdisp=kick_vdisp,
+            kick_slope=kick_slope,
+            kick_scale=kick_scale,
             **kwargs  # will error here if MF_kwargs included any of above args
         )
 
@@ -1707,7 +1721,11 @@ class EvolvedModel(Model):
                  a1=1.3, a2=2.3, a3=2.3, d=5,
                  s2=0., F=1., *, observations=None, age=None, FeH=None,
                  Zsun=0.02, m_breaks=[0.1, 0.5, 1.0, 100], nbins=[5, 5, 20],
-                 md=1.2, cbh_kwargs=None, MF_kwargs=None, **kwargs):
+                 tracer_masses=None, tcc=0.0, NS_ret=0.1, BH_ret_int=1.0,
+                 md=1.2, natal_kicks=True, kick_method='maxwellian',
+                 kick_vdisp=265., kick_slope=1, kick_scale=20,
+                 cbh_kwargs=None, MF_kwargs=None, meanmassdef='global',
+                 ode_maxstep=1e10, ode_rtol=1e-7):
         import clusterbh
 
         M0 <<= u.Msun
@@ -1763,21 +1781,32 @@ class EvolvedModel(Model):
                 cbh_kwargs.setdefault('rg', Rgal.to_value('kpc'))
 
             # Get age to evolve to
-            age = (observations.mdata['age'] << u.Gyr)
-            cbh_kwargs.setdefault('tend', age.to_value('Myr'))
+            if age is None:
+                age = observations.mdata['age'] << u.Gyr
+
+            if FeH is None:
+                FeH = observations.mdata['FeH']
+
+            # cbh_kwargs.setdefault('tend', age.to_value('Myr'))
 
             # Get metallicity
-            cbh_kwargs.setdefault('Z', Zsun * 10**observations.mdata['FeH'])
+            # cbh_kwargs.setdefault('Z', Zsun * 10**observations.mdata['FeH'])
+
+        else:
+            if age is None or FeH is None:
+                # Error here if age, FeH can't be found
+                mssg = ("Must supply either `age` and `FeH` or "
+                        "an `observations`, to read them from")
+                raise ValueError(mssg)
 
         # ------------------------------------------------------------------
         # Get age and metallicity, if given (TODO make this logic match others)
         # ------------------------------------------------------------------
 
-        if age is not None:
-            cbh_kwargs.setdefault('tend', age.to_value('Myr'))
+        age = age << u.Gyr
 
-        if FeH is not None:
-            cbh_kwargs.setdefault('Z', Zsun * 10**FeH)
+        cbh_kwargs.setdefault('tend', age.to_value('Myr'))
+        cbh_kwargs.setdefault('Z', Zsun * 10**FeH)
 
         cbh_kwargs.setdefault('Zsolar', Zsun)
 
@@ -1851,11 +1880,18 @@ class EvolvedModel(Model):
 
         BHret = -1  # Spoof unneeded BH retention fraction for `Model`
 
+        # Explicitly specify everything so we can get the correct Signature
         super().__init__(W0, M, rh, g=g, delta=delta, ra=ra,
                          a1=a1, a2=a2, a3=a3, BHret=BHret, d=d,
                          s2=s2, F=F, observations=observations, age=age,
                          FeH=FeH, m_breaks=m_breaks, vesc=vesc, esc_rate=Mdot_t,
-                         tcc=tcc, MF_kwargs=MF_kwargs, **kwargs)
+                         tcc=tcc, tracer_masses=tracer_masses,
+                         NS_ret=NS_ret, BH_ret_int=BH_ret_int,
+                         natal_kicks=natal_kicks, kick_method=kick_method,
+                         kick_vdisp=kick_vdisp, kick_slope=kick_slope,
+                         kick_scale=kick_scale, meanmassdef=meanmassdef,
+                         ode_maxstep=ode_maxstep, ode_rtol=ode_rtol,
+                         MF_kwargs=MF_kwargs)
 
         # reset theta to use initial values
         self.theta = dict(W0=W0, M0=M0.to_value('1e6 Msun'), rh0=rh0.value,

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -14,63 +14,20 @@ import itertools
 from collections import namedtuple
 
 
-__all__ = ['DEFAULT_THETA', 'DEFAULT_EV_THETA',
-           'Model', 'FittableModel', 'SingleMassModel',
-           'EvolvedModel', 'FittableEvolvedModel',
-           'SampledModel', 'Observations']
+__all__ = ['DEFAULT_FREE_PARAMS', 'DEFAULT_FREE_EV_PARAMS',
+           'Model', 'SingleMassModel', 'EvolvedModel', 'SampledModel',
+           'Observations']
 
 
-# The order of these is important!
-DEFAULT_THETA = {
-    'W0': 6.0,
-    'M': 0.69,
-    'rh': 2.88,
-    'ra': 1.23,
-    'g': 0.75,
-    'delta': 0.45,
-    's2': 0.1,
-    'F': 1.1,
-    'a1': 0.5,
-    'a2': 1.3,
-    'a3': 2.5,
-    'BHret': 0.5,
-    'd': 6.405,
-}
+DEFAULT_FREE_PARAMS = (
+    'W0', 'M', 'rh', 'ra', 'g', 'delta',
+    's2', 'F', 'a1', 'a2', 'a3', 'BHret', 'd',
+)
 
-
-DEFAULT_EV_THETA = {
-    'W0': 5.0,
-    'M0': 1.0,
-    'rh0': 3.0,
-    'ra': 1.23,
-    'g': 0.75,
-    'delta': 0.45,
-    's2': 0.1,
-    'F': 1.1,
-    'a1': 0.5,
-    'a2': 1.3,
-    'a3': 2.5,
-    'd': 6.405,
-}
-
-
-# When kicks/IFMR are free, ordering kick params before IFMR params is important
-DEFAULT_KICK_THETA = {
-    'kick_slope': 1,
-    'kick_scale': 20,
-}
-
-DEFAULT_IFMR_THETA = {
-    'IFMR_slope1': 5.,  # between 20 - 22.6
-    'IFMR_slope2': 7e-4,  # between 22.6 - 36
-    'IFMR_slope3': 0.03,  # between 36 - 150
-    'IFMR_scale1': -10,
-    'IFMR_scale2': -4,
-    'IFMR_scale3': 4,
-}
-
-# In some cases it is probably fine to have both (order is important)
-DEFAULT_BH_THETA = DEFAULT_KICK_THETA | DEFAULT_IFMR_THETA
+DEFAULT_FREE_EV_PARAMS = (
+    'W0', 'M0', 'rh0', 'ra', 'g', 'delta',
+    's2', 'F', 'a1', 'a2', 'a3', 'd',
+)
 
 
 # --------------------------------------------------------------------------
@@ -587,10 +544,6 @@ class Observations:
         self.mdata = {}
         self._dict_datasets = {}
 
-        self.initials = DEFAULT_THETA.copy()
-        self.ev_initials = DEFAULT_EV_THETA.copy()
-        self.BH_initials = DEFAULT_BH_THETA.copy()  # careful using this
-
         filename = util.get_cluster_path(cluster, standardize_name, restrict_to)
 
         self.cluster = filename.stem
@@ -610,17 +563,13 @@ class Observations:
             # Read in initial values of base free parameters
             # --------------------------------------------------------------
 
+            # I'm only gonna keep whats on file. You want more initials?
+            # Specify them to MCMC_fit yourself
             try:
-                # This updates defaults with data while keeping default sort
-                self.initials = {**self.initials, **file['initials'].attrs}
-
-                if extra := (self.initials.keys() - DEFAULT_THETA.keys()):
-                    mssg = (f"Stored initials do not match expected."
-                            f"Extra values found: {extra}")
-                    raise ValueError(mssg)
-
+                self.initials = dict(file['initials'].attrs)
             except KeyError:
-                logging.info("No initial state stored, using defaults")
+                self.initials = dict()
+                logging.debug("No initial state stored")
                 pass
 
             # --------------------------------------------------------------
@@ -628,40 +577,11 @@ class Observations:
             # --------------------------------------------------------------
 
             try:
-                self.ev_initials = {**self.ev_initials,
-                                    **file['ev_initials'].attrs}
-
-                if extra := (self.ev_initials.keys() - DEFAULT_EV_THETA.keys()):
-                    mssg = (f"Stored (evolved) initials do not match expected."
-                            f"Extra values found: {extra}")
-                    raise ValueError(mssg)
-
+                self.ev_initials = dict(file['ev_initials'].attrs)
             except KeyError:
-                logging.info("No (evolved) initial state stored, using default")
+                self.ev_initials = dict()
+                logging.debug("No (evolved) initial state stored")
                 pass
-
-            # --------------------------------------------------------------
-            # Read in initial values of BH-related free parameters
-            # --------------------------------------------------------------
-
-            try:
-                self.BH_initials = {**self.BH_initials,
-                                    **file['BH_initials'].attrs}
-
-                if extra := (self.BH_initials.keys() - DEFAULT_BH_THETA.keys()):
-                    mssg = (f"Stored (BH) initials do not match expected."
-                            f"Extra values found: {extra}")
-                    raise ValueError(mssg)
-
-            except KeyError:
-                logging.info("No (BH) initial state stored, using default")
-                pass
-
-            # isolate the kick and IFMR initials
-            self._kick_initials = {k: self.BH_initials[k]
-                                   for k in DEFAULT_KICK_THETA}
-            self._IFMR_initials = {k: self.BH_initials[k]
-                                   for k in DEFAULT_IFMR_THETA}
 
             # --------------------------------------------------------------
             # Read in all other metadata
@@ -1746,104 +1666,6 @@ class SingleMassModel(lp.limepy):
 
 
 # --------------------------------------------------------------------------
-# Model to be used in fitting to observations
-# --------------------------------------------------------------------------
-
-
-class FittableModel(Model):
-    '''Model subclass for use in all fitting functions.
-
-    A subclass of the base `Model`, with a simplified and specific
-    initilization signature based on a single `theta` input containing the main
-    13 model parameters, in a specific order, and `observations` which the
-    model should be compared to.
-
-    Unless you have a set of parameters `theta` taken directly from the fitting
-    results, you most likely do not want to use this class directly.
-
-    Parameters
-    ----------
-    theta : dict or list
-        The model input parameters. Must either be a dict, or a full list of
-        all parameters, in the exact same order as `DEFAULT_THETA`.
-        The 13 free parameters used here (W0, M, rh, ra, g, delta, a1, a2, a3,
-        BHret, s2, F and d) are key for defining the model structure, mass
-        evolution algorithm and fitting parameters.
-        See `Model` for further explanation of all possible input parameters.
-
-    observations : Observations
-        The `Observations` instance corresponding to this cluster. Required at
-        initilization so that the models can be compared to these observations
-        in the most consistent way possible.
-
-    **kwargs : dict
-        All other arguments are passed to `Model`.
-
-    Attributes
-    ----------
-    theta : dict
-        Dictionary of input parameters.
-        Some parameters may technically also be accessible directly as
-        attributes, but that interface should not be considered stable.
-        This dictionary should be used as the only direct access to any input
-        parameters that make up theta.
-
-    Notes
-    -----
-    The units of the inputs in `theta` here do not match those in `Model`
-    directly. `M` should be in units of [1e6 Msun] and ra should actually be
-    log10(ra).
-
-    All cluster metadata parameters (such as age, vesc, etc.) will be read from
-    the observations, and should not be provided as arguments here.
-    '''
-
-    def __init__(self, theta, observations, **kwargs):
-
-        self.observations = observations
-
-        # ------------------------------------------------------------------
-        # Unpack theta
-        # ------------------------------------------------------------------
-
-        if not isinstance(theta, dict):
-            theta = dict(zip(DEFAULT_THETA, theta))
-
-        else:
-            theta = theta.copy()
-
-        if missing_params := (DEFAULT_THETA.keys() - theta.keys()):
-            mssg = f"Missing required params: {missing_params}"
-            raise KeyError(mssg)
-
-        self.theta = theta
-
-        # ------------------------------------------------------------------
-        # Convert a few quantities
-        # ------------------------------------------------------------------
-
-        theta['M'] = theta['M'] * 1e6
-
-        theta['ra'] = 10**theta['ra']
-
-        # ------------------------------------------------------------------
-        # Create the base model
-        # ------------------------------------------------------------------
-
-        kwargs = kwargs.copy()
-
-        # Extra check if vesc/Ndot exist in obs first, otherwise use default
-        #   Necessary because checks in Model aren't sufficient
-        if ('vesc' not in kwargs) and ('vesc' in observations.mdata):
-            kwargs['vesc'] = observations.mdata['vesc'] << u.km / u.s
-
-        if ('esc_rate' not in kwargs) and ('esc_rate' in observations.mdata):
-            kwargs['esc_rate'] = observations.mdata['esc_rate']
-
-        super().__init__(observations=observations, **theta, **kwargs)
-
-
-# --------------------------------------------------------------------------
 # Model evolved from initial conditions using evolutionary model `clusterBH`
 # --------------------------------------------------------------------------
 
@@ -2046,51 +1868,6 @@ class EvolvedModel(Model):
         from ..analysis import EvolvedVisualizer
         return EvolvedVisualizer(self, observations=self.observations)
 
-
-class FittableEvolvedModel(EvolvedModel):
-    '''Evolved Model subclass for use in all fitting functions.'''
-
-    def __init__(self, theta, observations, **kwargs):
-
-        self.observations = observations
-
-        # ------------------------------------------------------------------
-        # Unpack theta
-        # ------------------------------------------------------------------
-
-        if not isinstance(theta, dict):
-            theta = dict(zip(DEFAULT_EV_THETA, theta))
-
-        else:
-            theta = theta.copy()
-
-        if missing_params := (DEFAULT_EV_THETA.keys() - theta.keys()):
-            mssg = f"Missing required params: {missing_params}"
-            raise KeyError(mssg)
-
-        self.theta = theta
-
-        # ------------------------------------------------------------------
-        # Convert a few quantities
-        # ------------------------------------------------------------------
-
-        theta['M0'] = theta['M0'] * 1e6
-
-        theta['ra'] = 10**theta['ra']
-
-        # ------------------------------------------------------------------
-        # Create the base model
-        # ------------------------------------------------------------------
-
-        kwargs = kwargs.copy()
-
-        # Extra check if esc_rate exist in obs first, otherwise use default
-        #   Necessary because checks in Model aren't sufficient
-
-        if ('esc_rate' not in kwargs) and ('esc_rate' in observations.mdata):
-            kwargs['esc_rate'] = observations.mdata['esc_rate']
-
-        super().__init__(observations=observations, **theta, **kwargs)
 
 # --------------------------------------------------------------------------
 # Sampled model

--- a/gcfit/core/main.py
+++ b/gcfit/core/main.py
@@ -396,7 +396,9 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
 
     logging.info("Beginning pool")
 
-    with schwimmbad.choose_pool(mpi=mpi, processes=Ncpu) as pool:
+    pool_kw = {'use_dill': True} if mpi else {}
+
+    with schwimmbad.choose_pool(mpi=mpi, processes=Ncpu, **pool_kw) as pool:
 
         logging.debug(f"Pool class: {pool}, with {mpi=}, {Ncpu=}")
 
@@ -782,7 +784,9 @@ def nested_fit(cluster, evolved=False, *, free_params=None,
 
     logging.info("Beginning pool")
 
-    with schwimmbad.choose_pool(mpi=mpi, processes=Ncpu) as pool:
+    pool_kw = {'use_dill': True} if mpi else {}
+
+    with schwimmbad.choose_pool(mpi=mpi, processes=Ncpu, **pool_kw) as pool:
 
         map_ = pool.map
 

--- a/gcfit/core/main.py
+++ b/gcfit/core/main.py
@@ -1,5 +1,6 @@
-from .data import Observations, DEFAULT_KICK_THETA, DEFAULT_IFMR_THETA
+from .data import Observations, DEFAULT_FREE_PARAMS, DEFAULT_FREE_EV_PARAMS
 from ..util.data import GCFIT_DIR
+from ..util.probabilities import ModelParameters
 from ..probabilities import posterior, priors
 
 import h5py
@@ -288,11 +289,12 @@ class NestedSamplingOutput(Output):
                 grp[key][-n_grow:] = val
 
 
-def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
-             mpi=False, initials=None, param_priors=None, moves=None,
+def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
+             Ncpu=2, mpi=False, initials=None, param_priors=None, moves=None,
              fixed_params=None, excluded_likelihoods=None, hyperparams=False,
              model_kwargs=None, cont_run=False, savedir=_here, backup=False,
-             restrict_to=None, compress=False, verbose=False, progress=False):
+             restrict_to=None, compress=False, param_transforms=None,
+             verbose=False, progress=False):
     '''Main MCMC fitting pipeline.
 
     Execute the full MCMC cluster fitting algorithm.
@@ -407,8 +409,11 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
         # Check arguments
         # ------------------------------------------------------------------
 
-        if fixed_params is None:
-            fixed_params = []
+        if free_params is None:
+            if evolved:
+                free_params = DEFAULT_FREE_EV_PARAMS
+            else:
+                free_params = DEFAULT_FREE_PARAMS
 
         if excluded_likelihoods is None:
             excluded_likelihoods = []
@@ -464,10 +469,20 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
         logging.debug(f"Likelihood components: {likelihoods}")
 
         # ------------------------------------------------------------------
+        # Set up ModelParameters
+        # ------------------------------------------------------------------
+
+        model_params = ModelParameters(free_params, model_kwargs,
+                                       observations=observations,
+                                       evolved=evolved,
+                                       param_transforms=param_transforms)
+
+        # ------------------------------------------------------------------
         # Initialize the walker positions
         # ------------------------------------------------------------------
 
         # *_params -> list of keys, *_initials -> dictionary
+        # TODO M, W0 and rh need guaranteed default initital positions
 
         spec_initials = initials
         obs_initials = (observations.initials if not evolved
@@ -482,20 +497,8 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
 
         logging.debug(f"Inital initals: {initials}")
 
-        if extraneous_params := (set(fixed_params) - initials.keys()):
-            raise ValueError(f"Invalid fixed parameters: {extraneous_params}")
+        variable_initials = {key: initials[key] for key in free_params}
 
-        variable_params = (initials.keys() - set(fixed_params))
-        if not variable_params:
-            mssg = f"No non-fixed parameters left, fix less parameters"
-            raise ValueError(mssg)
-
-        # variable params sorting matters for setup of theta, but fixed does not
-        fixed_initials = {key: initials[key] for key in fixed_params}
-        variable_initials = {key: initials[key] for key in
-                             sorted(variable_params, key=list(initials).index)}
-
-        logging.debug(f"Fixed initals: {fixed_initials}")
         logging.debug(f"Variable initals: {variable_initials}")
 
         init_pos = np.fromiter(variable_initials.values(), np.float64)
@@ -508,8 +511,8 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
         spec_priors = {k: {'type': v[0], 'args': v[1:]}
                        for k, v in param_priors.items()}
 
-        prior_kwargs = {'fixed_initials': fixed_initials, 'evolved': evolved}
-        prior_likelihood = priors.Priors(param_priors, **prior_kwargs)
+        prior_likelihood = priors.Priors(param_priors,
+                                         model_params=model_params)
 
         # check if initials are outside priors, if so then error right here
         if not np.isfinite(prior_likelihood(initials)):
@@ -521,6 +524,12 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
 
         backend.store_metadata('cluster', cluster)
         backend.store_metadata('evolved', evolved)
+        backend.store_metadata('free_params', free_params)
+
+        if param_transforms is not None:
+            # backend.store_metadata('param_transforms', param_transforms)
+            mssg = "passing parameter transforms to fitting is currently broken"
+            raise NotImplementedError(mssg)
 
         # Only store if set. Will default read to None if not stored here
         if restrict_to is not None:
@@ -534,7 +543,6 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
 
         backend.store_metadata('ndim', init_pos.shape[-1])
 
-        backend.store_metadata('fixed_params', fixed_initials)
         backend.store_metadata('excluded_likelihoods', excluded_likelihoods)
 
         if model_kwargs:
@@ -557,13 +565,13 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
         logging.info("Initializing sampler")
 
         sampler_kwargs = {'hyperparams': hyperparams, 'evolved': evolved,
-                          'return_indiv': True, 'model_kw': model_kwargs}
+                          'return_indiv': True}
 
         sampler = emcee.EnsembleSampler(
             nwalkers=Nwalkers,
             ndim=init_pos.shape[-1],
             log_prob_fn=posterior,
-            args=(observations, fixed_initials, likelihoods, prior_likelihood),
+            args=(observations, model_params, likelihoods, prior_likelihood),
             kwargs=sampler_kwargs,
             pool=pool,
             moves=moves,
@@ -645,14 +653,13 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, Ncpu=2, *,
     logging.info("FINISHED")
 
 
-def nested_fit(cluster, evolved=False, *,
-               flexible_IFMR=False, flexible_natal_kicks=False,
-               bound_type='multi', sample_type='auto',
+def nested_fit(cluster, evolved=False, *, free_params=None,
                initial_kwargs=None, batch_kwargs=None, model_kwargs=None,
+               bound_type='multi', sample_type='auto',
                pfrac=1.0, maxfrac=0.8, eff_samples=5000, plat_wt_func=False,
-               Ncpu=2, mpi=False, initials=None, param_priors=None,
-               fixed_params=None, excluded_likelihoods=None, hyperparams=False,
-               savedir=_here, restrict_to=None, compress=False, verbose=False):
+               Ncpu=2, mpi=False, param_priors=None, excluded_likelihoods=None,
+               hyperparams=False, savedir=_here, restrict_to=None,
+               compress=False, verbose=False, param_transforms=None):
     '''Main nested sampling fitting pipeline.
 
     Execute the full nested sampling cluster fitting algorithm.
@@ -790,8 +797,14 @@ def nested_fit(cluster, evolved=False, *,
         # Check arguments
         # ----------------------------------------------------------------------
 
-        if fixed_params is None:
-            fixed_params = []
+        if free_params is None:
+            if evolved:
+                free_params = DEFAULT_FREE_EV_PARAMS
+            else:
+                free_params = DEFAULT_FREE_PARAMS
+
+        # if fixed_params is None:
+        #     fixed_params = []
 
         if excluded_likelihoods is None:
             excluded_likelihoods = []
@@ -853,46 +866,15 @@ def nested_fit(cluster, evolved=False, *,
         logging.debug(f"Likelihood components: {likelihoods}")
 
         # ------------------------------------------------------------------
-        # Initialize the walker positions
+        # Set up ModelParameters
         # ------------------------------------------------------------------
 
-        # *_params -> list of keys, *_initials -> dictionary
-
-        spec_initials = initials
-        obs_initials = (observations.initials if not evolved
-                        else observations.ev_initials)
-
-        # get supplied initials, or read them from the data files if not given
-        if initials is None:
-            initials = obs_initials
-        else:
-            # fill manually supplied dict with defaults
-            initials = obs_initials | initials
-
-        # TODO technically these initials also make sense within obs probably
-        if flexible_natal_kicks:
-            initials |= DEFAULT_KICK_THETA
-
-        if flexible_IFMR:
-            initials |= DEFAULT_IFMR_THETA
-
-        logging.debug(f"Inital initals: {initials}")
-
-        if extraneous_params := (set(fixed_params) - initials.keys()):
-            raise ValueError(f"Invalid fixed parameters: {extraneous_params}")
-
-        variable_params = (initials.keys() - set(fixed_params))
-        if not variable_params:
-            mssg = "No non-fixed parameters left, fix less parameters"
-            raise ValueError(mssg)
-
-        # variable params sorting matters for setup of theta, but fixed does not
-        fixed_initials = {key: initials[key] for key in fixed_params}
-        variable_initials = {key: initials[key] for key in
-                             sorted(variable_params, key=list(initials).index)}
-
-        logging.debug(f"Fixed initals: {fixed_initials}")
-        logging.debug(f"Variable initals: {variable_initials}")
+        # TODO transforms only currently works (ie can be stored) with sympy
+        #   eqs; but those are off by default. So they don't really work at all
+        model_params = ModelParameters(free_params, model_kwargs,
+                                       observations=observations,
+                                       evolved=evolved,
+                                       transforms=param_transforms)
 
         # ------------------------------------------------------------------
         # Setup param_priors transforms
@@ -902,10 +884,9 @@ def nested_fit(cluster, evolved=False, *,
         spec_priors = {k: {'type': v[0], 'args': v[1:]}
                        for k, v in param_priors.items()}
 
-        prior_kwargs = {'fixed_initials': fixed_initials, 'err_on_fail': False,
-                        'evolved': evolved, 'flexible_IFMR': flexible_IFMR,
-                        'flexible_natal_kicks': flexible_natal_kicks}
-        prior_transform = priors.PriorTransforms(param_priors, **prior_kwargs)
+        prior_transform = priors.PriorTransforms(param_priors,
+                                                 model_params=model_params,
+                                                 err_on_fail=False)
 
         # ------------------------------------------------------------------
         # Write run metadata to output (backend) file
@@ -913,8 +894,12 @@ def nested_fit(cluster, evolved=False, *,
 
         backend.store_metadata('cluster', cluster)
         backend.store_metadata('evolved', evolved)
-        backend.store_metadata('flexible_natal_kicks', flexible_natal_kicks)
-        backend.store_metadata('flexible_IFMR', flexible_IFMR)
+        backend.store_metadata('free_params', free_params)
+
+        if param_transforms is not None:
+            # backend.store_metadata('param_transforms', param_transforms)
+            mssg = "passing parameter transforms to fitting is currently broken"
+            raise NotImplementedError(mssg)
 
         # Only store if set. Will default read to None if not stored here
         if restrict_to is not None:
@@ -926,8 +911,7 @@ def nested_fit(cluster, evolved=False, *,
         backend.store_metadata('mpi', mpi)
         backend.store_metadata('Ncpu', Ncpu)
 
-        ndim = len(variable_initials)
-        backend.store_metadata('ndim', ndim)
+        backend.store_metadata('ndim', model_params.ndim)
         backend.store_metadata('pfrac', pfrac)
         backend.store_metadata('maxfrac', maxfrac)
         backend.store_metadata('eff_samples', eff_samples)
@@ -936,7 +920,6 @@ def nested_fit(cluster, evolved=False, *,
 
         backend.store_metadata('hyperparams', hyperparams)
 
-        backend.store_metadata('fixed_params', fixed_initials)
         backend.store_metadata('excluded_likelihoods', excluded_likelihoods)
 
         if model_kwargs:
@@ -948,9 +931,6 @@ def nested_fit(cluster, evolved=False, *,
         if batch_kwargs:
             backend.store_metadata('batch_kwargs', batch_kwargs)
 
-        if spec_initials is not None:
-            backend.store_metadata('specified_initials', spec_initials)
-
         if spec_priors:
             backend.store_metadata('specified_priors', spec_priors)
 
@@ -960,18 +940,16 @@ def nested_fit(cluster, evolved=False, *,
 
         logging.info("Initializing sampler")
 
-        backend.ndim = ndim
+        backend.ndim = model_params.ndim
 
         logl_kwargs = {'hyperparams': hyperparams, 'evolved': evolved,
-                       'return_indiv': False, 'model_kw': model_kwargs,
-                       'flexible_IFMR': flexible_IFMR,
-                       'flexible_natal_kicks': flexible_natal_kicks}
+                       'return_indiv': False}
 
         sampler = dynesty.DynamicNestedSampler(
-            ndim=ndim,
+            ndim=model_params.ndim,
             loglikelihood=posterior,  # cause we need the defaults/checks it has
             prior_transform=prior_transform,
-            logl_args=(observations, fixed_initials, likelihoods, 'ignore'),
+            logl_args=(observations, model_params, likelihoods, 'ignore'),
             logl_kwargs=logl_kwargs,
             pool=pool,
             bound=bound_type,

--- a/gcfit/core/main.py
+++ b/gcfit/core/main.py
@@ -291,7 +291,7 @@ class NestedSamplingOutput(Output):
 
 def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
              Ncpu=2, mpi=False, initials=None, param_priors=None, moves=None,
-             fixed_params=None, excluded_likelihoods=None, hyperparams=False,
+             excluded_likelihoods=None, hyperparams=False,
              model_kwargs=None, cont_run=False, savedir=_here, backup=False,
              restrict_to=None, compress=False, param_transforms=None,
              verbose=False, progress=False):
@@ -323,6 +323,12 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
     Nwalkers : int
         Number of sampler walkers.
 
+    free_params : list of str, optional
+        List of parameters to allow to vary freely during fitting.
+        All other  parameters will be fixed to their default  (or
+        `model_kwargs`) values. By default the `DEFAULT_FREE_PARAMS` or
+        `DEFAULT_FREE_EV_PARAMS` will be used.
+
     Ncpu : int, optional
         Number of CPU's to parallelize the sampling computation over. Is
         ignored if `mpi` is True.
@@ -345,10 +351,6 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
         List of MCMC proposal algorithms, or "moves", as defined within `emcee`.
         This list is simply passed to `emcee.EnsembleSampler`.
 
-    fixed_params : list of str, optional
-        List of parameters to fix to the initial value, and not allow to be
-        varied through the sampler.
-
     excluded_likelihoods : list of str, optional
         List of component likelihoods to exclude from the posterior probability
         function. Each likelihood can be specified using either the name of
@@ -357,6 +359,12 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
     hyperparams : bool, optional
         Whether to include bayesian hyperparameters (see Hobson et al., 2002)
         in all likelihood functions.
+
+    model_kwargs : dict, optional
+        Values of any model parameters which will not be freely varying. Any
+        parameters given will override the defaults of the Model class.
+        Any model parameters which do not have any defaults should be provided
+        here, if they are not given in `free_params`.
 
     cont_run : bool, optional
         Not Implemented.
@@ -691,6 +699,12 @@ def nested_fit(cluster, evolved=False, *, free_params=None,
     cluster : str
         Cluster common name, as used to load `gcfit.Observations`.
 
+    free_params : list of str, optional
+        List of parameters to allow to vary freely during fitting.
+        All other  parameters will be fixed to their default  (or
+        `model_kwargs`) values. By default the `DEFAULT_FREE_PARAMS` or
+        `DEFAULT_FREE_EV_PARAMS` will be used.
+
     bound_type : {'none', 'single', 'multi', 'balls', 'cubes'}, optional
         Method used to approximately bound the prior using the current
         set of live points. Conditions the sampling methods used to propose
@@ -709,6 +723,12 @@ def nested_fit(cluster, evolved=False, *, free_params=None,
         Kwargs to be passed to the `dynesty.DynamicNestedSampler.sample_batch`
         batch sampling function. Defaults include `nlive_new` of 100.
         See `dynesty` for more info and all other defaults.
+
+    model_kwargs : dict, optional
+        Values of any model parameters which will not be freely varying. Any
+        parameters given will override the defaults of the Model class.
+        Any model parameters which do not have any defaults should be provided
+        here, if they are not given in `free_params`.
 
     pfrac : float, optional
         Fractional weight of the posterior (versus evidence) for stop function.
@@ -741,10 +761,6 @@ def nested_fit(cluster, evolved=False, *, free_params=None,
     param_priors : dict, optional
         Dictionary of prior bounds/args for each parameter.
         See `probabilities.priors` for formatting of args and defaults.
-
-    fixed_params : list of str, optional
-        List of parameters to fix to the initial value, and not allow to be
-        varied through the sampler.
 
     excluded_likelihoods : list of str, optional
         List of component likelihoods to exclude from the posterior probability
@@ -806,9 +822,6 @@ def nested_fit(cluster, evolved=False, *, free_params=None,
                 free_params = DEFAULT_FREE_EV_PARAMS
             else:
                 free_params = DEFAULT_FREE_PARAMS
-
-        # if fixed_params is None:
-        #     fixed_params = []
 
         if excluded_likelihoods is None:
             excluded_likelihoods = []

--- a/gcfit/probabilities/priors.py
+++ b/gcfit/probabilities/priors.py
@@ -1,4 +1,3 @@
-from ..core.data import DEFAULT_THETA
 
 import numpy as np
 from scipy import stats
@@ -7,8 +6,7 @@ import logging
 import operator
 
 
-__all__ = ["DEFAULT_PRIORS", "DEFAULT_EV_PRIORS",
-           "Priors", "UniformPrior", "GaussianPrior",
+__all__ = ["DEFAULT_PRIORS", "Priors", "UniformPrior", "GaussianPrior",
            "BoundedGaussianPrior", "CromwellUniformPrior", "ArbitraryPrior"]
 
 
@@ -87,19 +85,24 @@ class Priors:
         '''
 
         if not isinstance(theta, dict):
-            theta = dict(zip(self.var_params, theta), **self.fixed_initials)
+            theta = self._model_params.label_theta(theta)
+
+        full_args = self._model_params.build_args(theta, return_dict=True)
 
         L = {p: 0. for p in theta}
         inv = []
 
-        for param, prior in self.priors.items():
+        # for param, prior in self.priors.items():
+        for param, value in theta.items():
+
+            prior = self.priors[param]
 
             if prior.dependants:
-                deps = {d: theta[d] for d in prior.dependants}
-                P = prior(theta[param], **deps)
+                deps = {d: full_args[d] for d in prior.dependants}
+                P = prior(value, **deps)
 
             else:
-                P = prior(theta[param])
+                P = prior(value)
 
             # if invalid (ie 0, outside of bounds / real bad) record it's reason
             if P <= 0. or np.isnan(P):
@@ -127,46 +130,24 @@ class Priors:
 
         return L
 
-    def __init__(self, priors, fixed_initials=None, *,
-                 logged=True, err_on_fail=False,
-                 evolved=False,
-                 flexible_natal_kicks=False, flexible_IFMR=False):
+    def __init__(self, priors, model_params, *, logged=True, err_on_fail=False):
 
         self._log = logged
         self._strict = err_on_fail
 
-        defaults = DEFAULT_PRIORS if not evolved else DEFAULT_EV_PRIORS
-
-        if flexible_natal_kicks:
-            defaults |= DEFAULT_KICK_PRIORS
-
-        if flexible_IFMR:
-            defaults |= DEFAULT_IFMR_PRIORS
-
-        if extraneous_params := (priors.keys() - defaults.keys()):
-            raise ValueError(f"Invalid parameters: {extraneous_params}")
-
-        # ------------------------------------------------------------------
-        # Prep for any fixed parameters
-        # ------------------------------------------------------------------
-
-        # In normal prior likelihoods, the fixed values will also be evaled
-
-        if fixed_initials is None:
-            fixed_initials = {}
-
-        self.fixed_initials = fixed_initials
-
-        # get list of variable params, sorted for the later unpacking of theta
-        var_params = defaults.keys() - fixed_initials.keys()
-        self.var_params = sorted(var_params, key=list(defaults).index)
+        self._model_params = model_params
 
         # ------------------------------------------------------------------
         # Initialize all Prior objects
         # ------------------------------------------------------------------
 
         # Fill in unspecified parameters with default priors
-        self.priors = {**defaults, **priors}
+        # TODO this now carries around extra priors but thats probably fine
+        self.priors = {**DEFAULT_PRIORS, **priors}
+
+        if extra_params := (set(model_params.free_params) - self.priors.keys()):
+            mssg = f"No priors found for the free parameters {extra_params}"
+            raise ValueError(mssg)
 
         # Fill the dict with actual priors objects
         for param in self.priors:
@@ -226,7 +207,7 @@ class PriorTransforms(Priors):
         failure and continue.
     '''
 
-    def _compile_dependants(self, prior, U, theta=None):
+    def _compile_dependants(self, prior, U, theta):
         '''Transform a passed U to theta recursively, so can use dependants'''
 
         # TODO potentially repeating a lot of prior calls by not saving to theta
@@ -250,8 +231,7 @@ class PriorTransforms(Priors):
 
             # assume it's fixed, use its fixed value
             else:
-                # TODO might get hard to understand keyerror here if not fixed?
-                deps[dep_param] = self.fixed_initials[dep_param]
+                deps[dep_param] = self._model_params.fixed_params[dep_param]
 
         return deps
 
@@ -287,23 +267,20 @@ class PriorTransforms(Priors):
             flag was set on initialization.
         '''
 
-        if len(U) != len(self.var_params):
-            mssg = (f"Incorrect number of parameters passed: "
-                    f"expected {len(self.var_params)}, got {len(U)}")
-
-            raise ValueError(mssg)
-
         if not isinstance(U, dict):
-            U = dict(zip(self.var_params, U))
+            U = self._model_params.label_theta(U)
 
         theta = {}
         inv = []
 
-        for param, prior in self.priors.items():
+        for param, value in U.items():
+        # for param, prior in self.priors.items():
+
+            prior = self.priors[param]
 
             deps = self._compile_dependants(prior, U, theta)
 
-            theta[param] = prior(U[param], **deps)
+            theta[param] = prior(value, **deps)
 
             # if invalid, record it's reason
             if np.isnan(theta[param]):
@@ -323,47 +300,22 @@ class PriorTransforms(Priors):
 
         return theta
 
-    def __init__(self, priors, fixed_initials=None, *, err_on_fail=False,
-                 evolved=False,
-                 flexible_natal_kicks=False, flexible_IFMR=False):
+    def __init__(self, priors, model_params, *, err_on_fail=False):
 
         self._strict = err_on_fail
 
-        defaults = DEFAULT_PRIORS if not evolved else DEFAULT_EV_PRIORS
-
-        if flexible_natal_kicks:
-            defaults |= DEFAULT_KICK_PRIORS
-
-        if flexible_IFMR:
-            defaults |= DEFAULT_IFMR_PRIORS
-
-        if extraneous_params := (priors.keys() - defaults.keys()):
-            raise ValueError(f"Invalid parameters: {extraneous_params}")
-
-        # ------------------------------------------------------------------
-        # Prep for any fixed parameters
-        # ------------------------------------------------------------------
-
-        # In prior transforms, fixed values will be basically ignored
-
-        if fixed_initials is None:
-            fixed_initials = {}
-
-        self.fixed_initials = fixed_initials
-
-        # get list of variable params, sorted for the later unpacking of U
-        var_params = defaults.keys() - fixed_initials.keys()
-        self.var_params = sorted(var_params, key=list(defaults).index)
+        self._model_params = model_params
 
         # ------------------------------------------------------------------
         # Initialize all Prior objects
         # ------------------------------------------------------------------
 
         # Fill in unspecified parameters with default priors
-        self.priors = {**defaults, **priors}
+        self.priors = {**DEFAULT_PRIORS, **priors}
 
-        for key in self.fixed_initials:
-            del self.priors[key]
+        if extra_params := (set(model_params.free_params) - self.priors.keys()):
+            mssg = f"No priors found for the free parameters {extra_params}"
+            raise ValueError(mssg)
 
         # Fill the dict with actual priors objects
         for param in self.priors:
@@ -437,8 +389,9 @@ class _PriorBase:
         except ValueError:
             # val is a name of a param
 
-            if val not in DEFAULT_THETA:
-                raise ValueError(f'Invalid dependant parameter {val}')
+            # TODO can add check against model_params._all_params
+            # if val not in DEFAULT_THETA:
+            #     raise ValueError(f'Invalid dependant parameter {val}')
 
             self.dependants.append(val)
 
@@ -672,6 +625,7 @@ class CromwellUniformPrior(_PriorBase):
     pass
 
 
+# TODO these defaults of course assume `compatibility_transforms=True`
 DEFAULT_PRIORS = {
     'W0': ('uniform', [(3, 20)]),
     'M': ('uniform', [(0.01, 5)]),
@@ -685,30 +639,14 @@ DEFAULT_PRIORS = {
     'a2': ('uniform', [(-1, 2.35), ('a1', np.inf)]),
     'a3': ('uniform', [(1.6, 4), ('a2', np.inf)]),
     'BHret': ('uniform', [(0, 100)]),
-    'd': ('uniform', [(2, 18)])
-}
-
-DEFAULT_EV_PRIORS = {
-    'W0': ('uniform', [(3, 20)]),
+    'd': ('uniform', [(2, 18)]),
+    #
     'M0': ('uniform', [(0.001, 10)]),
-    'rh0': ('uniform', [(0.1, 50)]),
-    'ra': ('uniform', [(0, 5)]),
-    'g': ('uniform', [(0, 3.5)]),
-    'delta': ('uniform', [(0.3, 0.5)]),
-    's2': ('uniform', [(0, 15)]),
-    'F': ('uniform', [(1, 3)]),
-    'a1': ('uniform', [(-1, 2.35)]),
-    'a2': ('uniform', [(-1, 2.35), ('a1', np.inf)]),
-    'a3': ('uniform', [(1.6, 4), ('a2', np.inf)]),
-    'd': ('uniform', [(2, 18)])
-}
-
-DEFAULT_KICK_PRIORS = {
+    'rh0': ('uniform', [(0.01, 15)]),
+    #
+    'kick_vdisp': ('uniform', [(50, 265.)]),
     'kick_slope': ('uniform', [(1e-5, 2)]),
     'kick_scale': ('uniform', [(5, 100)]),
-}
-
-DEFAULT_IFMR_PRIORS = {
     'IFMR_slope1': ('uniform', [(0.1, 10)]),
     'IFMR_slope2': ('uniform', [(1e-6, 0.1)]),
     'IFMR_slope3': ('uniform', [(0.01, 2)]),
@@ -716,8 +654,6 @@ DEFAULT_IFMR_PRIORS = {
     'IFMR_scale2': ('uniform', [(-10, 20)]),
     'IFMR_scale3': ('uniform', [(-10, 20)])
 }
-
-DEFAULT_BH_PRIORS = DEFAULT_KICK_PRIORS | DEFAULT_IFMR_PRIORS
 
 _PRIORS_MAP = {
     "uniform": UniformPrior,

--- a/gcfit/probabilities/priors.py
+++ b/gcfit/probabilities/priors.py
@@ -38,9 +38,10 @@ class Priors:
         of ["prior name", *function args]. Any missing parameters will be filled
         in with `DEFAULT_PRIORS`.
 
-    fixed_initials : dict, optional
-        A dictionary of any parameters which have fixed values, used in cases of
-        dependant priors with these values.
+    model_params : ModelParameters
+        The `ModelParameters` instance being used during fitting. This is
+        necessary to determine which parameters are free, and what values to
+        use for any other required (dependant) parameters during computation.
 
     logged : bool, optional
         Whether to log the returned likelihoods. Defaults to True.
@@ -194,9 +195,10 @@ class PriorTransforms(Priors):
         of ["prior name", *function args]. Any missing parameters will be filled
         in with `DEFAULT_PRIORS`.
 
-    fixed_initials : dict, optional
-        A dictionary of any parameters which have fixed values, used in cases of
-        dependant priors with these values.
+    model_params : ModelParameters
+        The `ModelParameters` instance being used during fitting. This is
+        necessary to determine which parameters are free, and what values to
+        use for any other required (dependant) parameters during computation.
 
     logged : bool, optional
         Whether to log the returned likelihoods. Defaults to True.

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -1,9 +1,7 @@
 from .pulsars import *
 from .priors import Priors
 from .. import util
-from ..core.data import (DEFAULT_THETA, DEFAULT_EV_THETA,
-                         DEFAULT_KICK_THETA, DEFAULT_IFMR_THETA,
-                         FittableModel, FittableEvolvedModel)
+from ..core.data import Model, EvolvedModel
 
 import numpy as np
 import astropy.units as u
@@ -1058,8 +1056,8 @@ def likelihood_mass_func(model, mf, fields, *, hyperparams=False):
 # --------------------------------------------------------------------------
 
 
-def log_likelihood(theta, observations, L_components, hyperparams, evolved,
-                   **model_kw):
+def log_likelihood(theta, observations, model_params, L_components,
+                   hyperparams, evolved, **model_kw):
     r'''Compute log likelihood of given `theta`, based on component likelihoods.
 
     Main likelihood function, which generates the relevant model based on
@@ -1113,16 +1111,19 @@ def log_likelihood(theta, observations, L_components, hyperparams, evolved,
                  = \sum_i \ln(\mathcal{L}_i(\Theta)))
     '''
 
-    if evolved:
-        model_cls = FittableEvolvedModel
-    else:
-        model_cls = FittableModel
+    model_cls = EvolvedModel if evolved else Model
+
+    params = model_params.build_args(theta)
 
     try:
-        model = model_cls(theta, observations, **model_kw)
+        model = model_cls(*params.args, **params.kwargs)
+
     except ValueError as err:
-        mssg = f"Model did not converge with {theta=} **{model_kw=}({err})"
+
+        mssg = (f"Model did not converge with {theta=} "
+                f"(`Model(*{params.args=}, **{params.kwargs=})`) -> ({err})")
         logging.debug(mssg)
+
         return -np.inf, -np.inf * np.ones(len(L_components))
 
     # Calculate each log likelihood
@@ -1136,11 +1137,10 @@ def log_likelihood(theta, observations, L_components, hyperparams, evolved,
     return sum(probs), probs
 
 
-def posterior(theta, observations, fixed_initials=None,
+def posterior(theta, observations, model_params,
               L_components=None, prior_likelihood=None, *,
               hyperparams=False, return_indiv=True,
-              evolved=False, flexible_natal_kicks=False, flexible_IFMR=False,
-              model_kw=None):
+              evolved=False):
     '''Compute the full posterior probability given `theta` and `observations`.
 
     Combines the various likelihood functions (through `log_likelihood`)
@@ -1191,9 +1191,6 @@ def posterior(theta, observations, fixed_initials=None,
         alongside the posterior probability. Can be used by some sampler
         classes, such as the `blobs` functionality of `emcee`.
 
-    model_kw : dict, optional
-        Extra arguments to be passed to the initialization of all models.
-
     Returns
     -------
     float or tuple
@@ -1203,28 +1200,11 @@ def posterior(theta, observations, fixed_initials=None,
         individual log likelihood values for each likelihood function.
     '''
 
-    if fixed_initials is None:
-        fixed_initials = {}
-
     if L_components is None:
         L_components = observations.valid_likelihoods
 
     if prior_likelihood is None:
-        prior_likelihood = Priors(dict(), evolved=evolved)
-
-    if evolved:
-        default_θ = DEFAULT_EV_THETA.copy()
-    else:
-        default_θ = DEFAULT_THETA.copy()
-
-    if flexible_natal_kicks:
-        default_θ |= DEFAULT_KICK_THETA.copy()
-
-    if flexible_IFMR:
-        default_θ |= DEFAULT_IFMR_THETA.copy()
-
-    if model_kw is None:
-        model_kw = {}
+        prior_likelihood = Priors(dict(), model_params=model_params)
 
     # Check if any values of theta are not finite, probably caused by invalid
     # prior transforms, and indicating we should return -inf
@@ -1234,13 +1214,6 @@ def posterior(theta, observations, fixed_initials=None,
             return -np.inf, *(-np.inf * np.ones(len(L_components)))
         else:
             return -np.inf
-
-    # get a list of variable params, sorted for the unpacking of theta
-    variable_params = default_θ.keys() - fixed_initials.keys()
-    params = sorted(variable_params, key=list(default_θ).index)
-
-    # TODO add type check on theta, cause those exceptions aren't very pretty
-    theta = dict(zip(params, theta)) | fixed_initials
 
     # prior likelihoods
     if prior_likelihood != 'ignore':
@@ -1255,20 +1228,15 @@ def posterior(theta, observations, fixed_initials=None,
     else:
         log_Pθ = 0
 
-    # Eat the BH params again
-    if flexible_natal_kicks or flexible_IFMR:
-        theta, MF_kwargs = util.pop_flexible_BHs(theta, flexible_natal_kicks,
-                                                 flexible_IFMR)
-
-        model_kw['MF_kwargs'] = model_kw.get('MF_kwargs', dict()) | MF_kwargs
-
-    log_L, individuals = log_likelihood(theta, observations, L_components,
+    log_L, individuals = log_likelihood(theta, observations, model_params,
+                                        L_components=L_components,
                                         hyperparams=hyperparams,
-                                        evolved=evolved, **model_kw)
+                                        evolved=evolved)
 
     probability = log_L + log_Pθ
 
     if return_indiv:
+        # TODO this `individuals` does not include any prior likelihood
         return probability, *individuals
     else:
         return probability

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -1057,7 +1057,7 @@ def likelihood_mass_func(model, mf, fields, *, hyperparams=False):
 
 
 def log_likelihood(theta, observations, model_params, L_components,
-                   hyperparams, evolved, **model_kw):
+                   hyperparams, evolved):
     r'''Compute log likelihood of given `theta`, based on component likelihoods.
 
     Main likelihood function, which generates the relevant model based on
@@ -1077,6 +1077,10 @@ def log_likelihood(theta, observations, model_params, L_components,
         initialize the model and to read in all datasets specified by
         `L_components`.
 
+    model_params : ModelParameters
+        The `ModelParameters` instance being used during fitting. Will be used
+        to construct the model class based on `theta`.
+
     L_components : list of lists
         List of likelihood components to compute. Must be a list of lists
         in the same format as `Observations.valid_likelihoods` (dataset name,
@@ -1084,9 +1088,6 @@ def log_likelihood(theta, observations, model_params, L_components,
 
     hyperparams : bool
         Whether to include bayesian hyperparameters in all likelihood functions.
-
-    **model_kw : dict, optional
-        All other arguments are passed to the model class
 
     Returns
     -------
@@ -1164,11 +1165,9 @@ def posterior(theta, observations, model_params,
         The `Observations` instance corresponding to this cluster, to provide
         the "data" for this posterior calculation.
 
-    fixed_initials : dict, optional
-        An optional dictionary of parameters which provides fixed values for
-        specific parameters used to fill out the `theta` array. This is useful
-        for allowing samplers to explore a smaller set of parameters by fixing
-        certain usually free ones.
+    model_params : ModelParameters
+        The `ModelParameters` instance being used during fitting. Will be used
+        to construct the model class based on `theta`.
 
     L_components : list of lists, optional
         List of likelihood components to compute. Must be a list of lists

--- a/gcfit/scripts/GCfitter.py
+++ b/gcfit/scripts/GCfitter.py
@@ -103,25 +103,37 @@ def main():
     parallel_group.add_argument("--mpi", action="store_true",
                                 help="Run with MPI rather than multiprocessing")
 
+    shared_parser.add_argument('--free', dest='free_params', nargs='*',
+                               default=None,
+                               help='Free parameters to fit on. All other '
+                                    'parameters will be fixed to their default '
+                                    '(or --model-kwargs) values. By default '
+                                    'the 13 typical free parameters will be '
+                                    'used (W0, M/1e6, rh, log(ra), g, delta, '
+                                    's2, F, a1, a2, a3, BHret, d).')
+
     shared_parser.add_argument('--restrict-to', default=None,
                                choices={None, 'local', 'core'},
                                help='Optionally restrict datafiles used to '
                                     '"core" or "local" cluster files')
     shared_parser.add_argument('--savedir', default=default_dir,
                                help='location of saved sampling runs')
-    shared_parser.add_argument('-i', '--initials',
-                               help='alternative JSON file '
-                                    'with different intials')
+
     shared_parser.add_argument('-p', '--priors', dest='param_priors',
-                               help='alternative JSON file '
+                               help='Alternative JSON file '
                                     'with different priors')
     shared_parser.add_argument('--model-kwargs',
-                               help='alternative JSON file '
-                                    'with different model kwargs')
+                               help='Alternative JSON file '
+                                    'with different model kwargs. These '
+                                    'parameters will be passed to the model '
+                                    'init each time, and will be used as the '
+                                    '"fixed" value of all non-free parameters')
 
     shared_parser.add_argument('--fix', dest='fixed_params', nargs='*',
-                               help='Parameters to fix, '
-                                    'not estimate from the sampler')
+                               help='Parameters to fix, not estimate from the '
+                               'sampler. This is only really required for a '
+                               'specific setup, and it is recommended to just '
+                               'use --free to specify which params are free')
 
     shared_parser.add_argument('--exclude', nargs='*',
                                dest='excluded_likelihoods',
@@ -135,21 +147,6 @@ def main():
     shared_parser.add_argument('--evolved', dest='evolved',
                                action='store_true',
                                help="Use evolved models")
-
-    shared_parser.add_argument('--flexible-BHs', dest='flexible_BHs',
-                               action='store_true',
-                               help="Allow all BH physics to vary freely."
-                                    "Identical to providing both "
-                                    "--flexible-IFMR and "
-                                    "--flexible-natal-kicks")
-
-    shared_parser.add_argument('--flexible-IFMR', dest='flexible_IFMR',
-                               action='store_true',
-                               help="Allow BH IFMR to vary freely.")
-
-    shared_parser.add_argument('--flexible-natal-kicks', dest='flexible_natal_kicks',
-                               action='store_true',
-                               help="Allow BH natal kicks to vary freely.")
 
     shared_parser.add_argument('--verbose', action='store_true')
     shared_parser.add_argument('--debug', action='store_true')
@@ -173,6 +170,10 @@ def main():
                              help='Number of sampling iterations')
     parser_MCMC.add_argument('--Nwalkers', required=True, type=pos_int,
                              help='Number of walkers for MCMC sampler')
+
+    parser_MCMC.add_argument('-i', '--initials',
+                             help='Alternative JSON file with desired initial '
+                                  'positions of walkers')
 
     parser_MCMC.add_argument('--moves', type=str.lower, nargs='*',
                              default=['stretchmove'],
@@ -242,15 +243,18 @@ def main():
     # Common arguments
     # ----------------------------------------------------------------------
 
-    if args.initials:
-
-        if (init_file := pathlib.Path(args.initials)).is_file():
-
-            with open(init_file, 'r') as init_of:
-                args.initials = json.load(init_of)
-
+    if args.free_params is None:
+        if args.evolved:
+            args.free_params = gcfit.DEFAULT_FREE_EV_PARAMS
         else:
-            parser.error(f"Cannot access '{init_file}': No such file")
+            args.free_params = gcfit.DEFAULT_FREE_PARAMS
+
+        if args.fixed_params:
+            # maintain sort order
+            args.free_params = [fp for fp in args.free_params
+                                if fp not in args.fixed_params]
+
+    del args.fixed_params
 
     if args.param_priors:
 
@@ -274,16 +278,21 @@ def main():
 
     pathlib.Path(args.savedir).mkdir(exist_ok=True)
 
-    if args.flexible_BHs:
-        args.flexible_IFMR = args.flexible_natal_kicks = True
-
-    del args.flexible_BHs
-
     # ----------------------------------------------------------------------
     # MCMC specific arguments
     # ----------------------------------------------------------------------
 
     if args.sampler == 'MCMC':
+
+        if args.initials:
+
+            if (init_file := pathlib.Path(args.initials)).is_file():
+
+                with open(init_file, 'r') as init_of:
+                    args.initials = json.load(init_of)
+
+            else:
+                parser.error(f"Cannot access '{init_file}': No such file")
 
         if args.cont_run:
             raise NotImplementedError

--- a/gcfit/util/probabilities.py
+++ b/gcfit/util/probabilities.py
@@ -3,7 +3,7 @@ from .units import QuantitySpline
 
 __all__ = ['gaussian', 'RV_transform', 'gaussian_likelihood',
            'hyperparam_likelihood', 'hyperparam_effective', 'div_error',
-           'pop_flexible_BHs', 'trim_peaks', 'find_intersections']
+           'ModelParameters', 'trim_peaks', 'find_intersections']
 
 # --------------------------------------------------------------------------
 # Generic Distribution Helpers
@@ -97,31 +97,111 @@ def div_error(a, a_err, b, b_err):
 # --------------------------------------------------------------------------
 
 
-# TODO the methods chosen are obviously not very "flexible"
-def pop_flexible_BHs(theta, flexible_natal_kicks=True, flexible_IFMR=True):
-    '''Convert theta using `flexible-BHs` to a normal theta.'''
-    MF_kwargs = dict()
+class ModelParameters:
+    '''Helper class meant to parse and setup parameters for use by model fitting
+    with the ultimate aim of simplifying the handling of free and fixed params
+    and of making it much simpler to allow various parameters to freely vary.
+    '''
 
-    if flexible_natal_kicks:
+    def __init__(self, free_params: tuple[str, ...],
+                 model_kwargs: dict|None=None, observations=None,
+                 evolved: bool=False,
+                 transforms: dict|None=None, sympy_transforms: bool=False,
+                 compatibility_transforms: bool=True):
+        import inspect
+        from ..core.data import Model, EvolvedModel
 
-        MF_kwargs['kick_method'] = 'sigmoid'
-        MF_kwargs['kick_slope'] = theta.pop('kick_slope')
-        MF_kwargs['kick_scale'] = theta.pop('kick_scale')
+        self._signature = inspect.signature(EvolvedModel if evolved else Model)
 
-    if flexible_IFMR:
+        self._all_params = list(self._signature.parameters.values())
 
-        MF_kwargs['BH_IFMR_method'] = 'bpl'
-        Ncomp = 3
+        self._reqd_params = [prm for prm in self._all_params
+                             if (prm.default is prm.empty)
+                             and (prm.kind is not prm.VAR_KEYWORD)]
 
-        slopes = [theta.pop(f'IFMR_slope{i}') for i in range(1, Ncomp + 1)]
-        scales = [theta.pop(f'IFMR_scale{i}') for i in range(1, Ncomp + 1)]
+        if model_kwargs is None:
+            model_kwargs = dict()
 
-        MF_kwargs['BH_IFMR_kwargs'] = dict(
-            slopes=slopes, scales=scales,
-            exponents=[0.5, 3, 1.5], m_breaks=[20, 22.7, 36, 150.1]
-        )
+        if extra := (set(free_params) - {prm.name for prm in self._all_params}):
+            raise ValueError(f"Invalid parameters: {extra}")
 
-    return theta, MF_kwargs
+        # Some params don't have defaults. It's not that they must be free, but
+        # should be free or specifically given (and thus fixed) (M, W0, rh)
+        given_params = set(free_params) | model_kwargs.keys()
+        if miss := ({prm.name for prm in self._reqd_params} - given_params):
+            raise ValueError(f"Missing required parameters: {miss}")
+
+        if (ndim := len(free_params)) < 1:
+            raise ValueError("Must have at least one free parameter.")
+
+        # Check for sympy transforms (for fun)
+        if transforms is not None and sympy_transforms:
+            # I don't love the idea of making sympy the default, but they're
+            # also the only kind of transforms I could easily store and recreate
+            import sympy
+            for prm, func in transforms.items():
+                if not callable(func):
+                    transforms[prm] = sympy.lambdify(prm, func)
+
+        # For backwards compatibility, add in the historically used transforms
+        if transforms is None and compatibility_transforms:
+            transforms = {'M': lambda M: 1e6 * M,
+                          'M0': lambda M: 1e6 * M,
+                          'ra': lambda ra: 10**ra}
+
+        # TODO check that params are not in both free and fixed, and model_kw
+
+        self.free_params = free_params
+        self.model_kwargs = model_kwargs
+        self.ndim = ndim
+        self._obs = observations  # explicit and special
+        self.transforms = transforms
+
+        fixedargs = self._signature.bind_partial(observations=self._obs,
+                                                 **self.model_kwargs)
+        fixedargs.apply_defaults()
+        self.fixed_params = {k: v for k, v in fixedargs.arguments.items()
+                             if k not in self.free_params}
+
+    def label_theta(self, theta):
+        '''turn theta into a dict'''
+        try:
+            return dict(zip(self.free_params, theta, strict=True))
+        except ValueError as err:
+            mssg = (f'Given theta (size {len(theta)}) does not match number '
+                    f'of free parameters (size {self.ndim})')
+            raise ValueError(mssg) from err
+
+    def build_args(self, theta, *, return_dict=False):
+        '''call model with Model(*build_args.args, **build_args.kwargs)'''
+
+        if isinstance(theta, dict):
+
+            if theta.keys() != set(self.free_params):
+                mssg = 'Given `theta` dict does not match the free parameters'
+                raise ValueError(mssg)
+
+            free_theta = theta
+
+        else:
+
+            free_theta = self.label_theta(theta=theta)
+
+        if self.transforms is not None:
+            free_theta = {prm: self.transforms.get(prm, lambda v: v)(val)
+                          for prm, val in free_theta.items()}
+
+        kwargs = free_theta | self.model_kwargs | {'observations': self._obs}
+
+        boundargs = self._signature.bind(**kwargs)
+
+        # Fill in given params with Model defaults
+        boundargs.apply_defaults()
+
+        if return_dict:
+            return boundargs.arguments
+        else:
+            return boundargs
 
 
 # --------------------------------------------------------------------------

--- a/gcfit/util/probabilities.py
+++ b/gcfit/util/probabilities.py
@@ -98,9 +98,59 @@ def div_error(a, a_err, b, b_err):
 
 
 class ModelParameters:
-    '''Helper class meant to parse and setup parameters for use by model fitting
-    with the ultimate aim of simplifying the handling of free and fixed params
-    and of making it much simpler to allow various parameters to freely vary.
+    '''Helper class for parsing Model parameters for fitting
+
+    In order to make the handling of free parameters during model fitting more
+    flexible, extensible and secure, this class handles all arguments passed
+    to the initialization of the desired model class. Based on the function
+    signature of `__init__`, it determines which parameters are valid, and
+    provides methods for easily transforming an array of free parameter
+    values to a useable function signature.
+
+    This class eliminates the need for having fixed sets of possible free
+    model parameters, allowing each different fitting run to be its own.
+
+    Models can be initialized by calling:
+    `Model(*modelparams.build_args(θ).args, **modelparams.build_args(θ).kwargs)`
+
+    Parameters
+    ----------
+    free_params : tuple of str
+        The names of which parameters will be freely varied. The order of this
+        must be matched by whatever data is passed to the constructor methods.
+        The parameters must be valid (i.e. appear directly in the signature)
+        for the relevant Model class, and must be parameters which accept a
+        single scalar value.
+
+    model_kwargs : dict, optional
+        Values of any model parameters which will not be freely varying. Any
+        parameters given will override the defaults of the Model class. These
+        parameters are not restricted to scalar arguments. Any model parameters
+        which do not have any defaults must be provided here, if they are
+        not given in `free_params`.
+
+    observations : gcfit.Observations, optional
+        The `Observations` instance to be provided to the Model class. Appears
+        here directly as it is handled specially. Should not be given in
+        `model_kwargs`.
+
+    evolved : bool, optional
+        Whether to use the `Model` or `EvolvedModel` class. Important for
+        determining the correct valid parameters. Defaults to `Model` class.
+
+    transforms : dict, optional
+        Optional dictionaries of scalar->scalar functions which will be applied
+        to the relevant parameters when given to the one of the argument
+        building methods. Necessary if, for example, you wish to vary the log
+        of a parameter, rather than the parameter itself.
+
+    sympy_transforms : bool, optional
+        Flag allowing the passed transforms to be strings parseable by sympy,
+        rather than callable functions.
+
+    compatibility_transforms : bool, optional
+        By default, use some transforms that have always been used in the past,
+        mostly for backwards compatibility. Namely, `M * 1e6` and `10**ra`.
     '''
 
     def __init__(self, free_params: tuple[str, ...],
@@ -164,7 +214,7 @@ class ModelParameters:
                              if k not in self.free_params}
 
     def label_theta(self, theta):
-        '''turn theta into a dict'''
+        '''Turn theta into a dict with correct parameter names'''
         try:
             return dict(zip(self.free_params, theta, strict=True))
         except ValueError as err:
@@ -173,7 +223,7 @@ class ModelParameters:
             raise ValueError(mssg) from err
 
     def build_args(self, theta, *, return_dict=False):
-        '''call model with Model(*build_args.args, **build_args.kwargs)'''
+        '''Build the Model arguments required to init a model with theta.'''
 
         if isinstance(theta, dict):
 


### PR DESCRIPTION
This PR rethinks and restructures how Models are constructed and free parameters are handled, during fitting, with the major goal of making fitting much more flexible wrt which parameters are allowed to vary freely.

The main difference is that the `Fittable*` model classes are removed, and instead the `ModelParameters` class is created and used during fitting. This class is based on the `__init__` signatures of the model classes directly, and thus no longer rely on a set of hard-coded (usually) free parameters, and instead let any valid scalar argument to `Model` or `EvolvedModel` to be freed during fitting.

This was motivated by the need to rewrite large parts of the codebase whenever you wanted to try fitting a new parameter, like those related to BH kicks.