### PR TITLE
Feature/more equipartition

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -2575,7 +2575,7 @@ class _ClusterVisualizer:
         # Try to plot the various radii quantities from this model, if desired
         # ------------------------------------------------------------------
 
-        valid_rs = {'rh', 'ra', 'rt', 'r0', 'rhp', 'rv'}
+        valid_rs = {'rh', 'ra', 'rt', 'r0', 'rhp', 'rv', 'rc_obs'}
 
         q = [84.13, 50., 15.87]
 
@@ -3583,6 +3583,7 @@ class ModelVisualizer(_ClusterVisualizer):
 
         # various structural model attributes
         self.r0 = model.r0
+        self.rc_obs = model.rc_obs
         self.rh = model.rh
         self.rhp = model.rhp
         self.ra = model.ra
@@ -4436,6 +4437,7 @@ class CIModelVisualizer(_ClusterVisualizer):
         mmean_t = np.full((1, N, Nt), np.nan) << huge_model.mmean.unit
 
         r0 = np.full(N, np.nan) << huge_model.r0.unit
+        rc_obs = np.full(N, np.nan) << huge_model.rc_obs.unit
         rt = np.full(N, np.nan) << huge_model.rt.unit
         rh = np.full(N, np.nan) << huge_model.rh.unit
         rhp = np.full(N, np.nan) << huge_model.rhp.unit
@@ -4588,6 +4590,7 @@ class CIModelVisualizer(_ClusterVisualizer):
             mmean_t[slc] = model.mmean
 
             r0[model_ind] = model.r0
+            rc_obs[model_ind] = model.rc_obs
             rt[model_ind] = rt_t[slc] = model.rt
             rh[model_ind] = rh_t[slc] = model.rh
             rhp[model_ind] = model.rhp
@@ -4693,6 +4696,7 @@ class CIModelVisualizer(_ClusterVisualizer):
         viz.M_kicked = M_kicked
 
         viz.r0 = r0
+        viz.rc_obs = rc_obs
         viz.rt = rt
         viz.rh = rh
         viz.rhp = rhp
@@ -5074,7 +5078,8 @@ class CIModelVisualizer(_ClusterVisualizer):
 
             quant_keys = (
                 'f_rem', 'f_BH', 'M_BH', 'N_BH', 'M_NS', 'N_NS', 'M_WD', 'N_WD',
-                'f_BH0', 'M_BH0', 'N_BH0', 'r0', 'rt', 'rh', 'rhp', 'ra', 'rv',
+                'f_BH0', 'M_BH0', 'N_BH0',
+                'r0', 'rc_obs', 'rt', 'rh', 'rhp', 'ra', 'rv',
                 'mmean', 'volume', 'vesc0', 'rhoh0', 'BH_rh', 'NS_rh', 'WD_rh',
                 'spitzer_chi', 'trh', 'N_relax', 'K_scale',
                 'M_kicked', 'delta_r50', 'delta_A'
@@ -6053,6 +6058,7 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
         mmean_t = np.full((1, N, Nt), np.nan) << huge_model.mmean.unit
 
         r0 = np.full(N, np.nan) << huge_model.r0.unit
+        rc_obs = np.full(N, np.nan) << huge_model.rc_obs.unit
         rt = np.full(N, np.nan) << huge_model.rt.unit
         rh = np.full(N, np.nan) << huge_model.rh.unit
         rhp = np.full(N, np.nan) << huge_model.rhp.unit
@@ -6211,6 +6217,7 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
             mmean_t[slc] = cbh.mav << mmean_t.unit
 
             r0[model_ind] = model.r0
+            rc_obs[model_ind] = model.rc_obs
             rt[model_ind] = model.rt
             rt_t[slc] = cbh.rt << rt_t.unit
             rh[model_ind] = model.rh
@@ -6324,6 +6331,7 @@ class CIEvolvedVisualizer(CIModelVisualizer, EvolvedVisualizer):
         viz.N_BH0 = N_BH0
 
         viz.r0 = r0
+        viz.rc_obs = rc_obs
         viz.rt = rt
         viz.rh = rh
         viz.rhp = rhp

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1055,6 +1055,7 @@ class Model(lp.limepy):
         # TODO this may be wrong (it's "phase-space" volume)
         self.volume <<= R_units**3
 
+        self.v2 <<= V2_units
         self.v2T <<= V2_units
         self.v2Tj <<= V2_units
         self.v2R <<= V2_units
@@ -1324,6 +1325,37 @@ class Model(lp.limepy):
         # ------------------------------------------------------------------
         # Get some derived quantities
         # ------------------------------------------------------------------
+
+        # King concentration parameter
+
+        self.c = np.log10(self.rt / self.r0)
+
+        # Different core radius definitions
+
+        # Casertano & Hut, 1985 density radius (eq. IV.2)
+        integ = (self.rho**2) * (self.r**3)
+        norm = (self.rho**2) * (self.r**2)
+        self.rc_casertano = (
+            util.QuantitySpline(x=self.r, y=integ).integral(self.r[0], self.rt)
+            / util.QuantitySpline(x=self.r, y=norm).integral(self.r[0], self.rt)
+        )
+
+        # Casertano & Hut, 1985 surface density radius (eq. IV.4)
+        integ = (self.Sigma**2) * (self.r**2)
+        norm = (self.Sigma**2) * (self.r**1)
+        self.rc_casertano_surf = (
+            util.QuantitySpline(x=self.r, y=integ).integral(self.r[0], self.rt)
+            / util.QuantitySpline(x=self.r, y=norm).integral(self.r[0], self.rt)
+        )
+
+        # Spitzer, 1987
+        self.rc_spitzer = ((3 * self.v2[0])
+                           / (4 * np.pi * self.G * self.rho[0]))**0.5
+
+        # "Observable" core radius (analogous to Morscher+2015 / King1962)
+        self.rc_obs = util.QuantitySpline(
+            self.r, self.Sigmaj[self.nms-1] - (0.5 * self.Sigmaj[self.nms-1][0])
+        ).roots()[0]
 
         # Escape Velocity
 
@@ -2443,6 +2475,7 @@ class SampledModel:
         self.rhj = model.rhj
         self.rhp = model.rhp
         self.rt = model.rt
+        self.r0 = model.r0
 
         self.raj = np.repeat(model.raj, self.Nj)
         self.s2j = np.repeat(model.s2j, self.Nj)

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -850,7 +850,7 @@ class Model(lp.limepy):
 
     m_breaks : (4,) numpy.ndarray or astropy.Quantity, optional
         The IMF break-masses (including outer bounds) in Msun, defining the
-        mass ranges of each IMF exponent. Defaults to [0.1, 0.5, 1.0, 100].
+        mass ranges of each IMF exponent. Defaults to [0.1, 0.5, 1.0, 150].
 
     nbins : (3,) numpy.ndarray of int, optional
         Number of mass bins in each regime of the IMF, as defined by `m_breaks`.
@@ -1092,13 +1092,14 @@ class Model(lp.limepy):
     def __init__(self, W0, M, rh, g=1.5, delta=0.45, ra=1e8,
                  a1=1.3, a2=2.3, a3=2.3, BHret=5.0, d=5,
                  s2=0., F=1., *, observations=None, age=None, FeH=None,
-                 m_breaks=[0.1, 0.5, 1.0, 100], nbins=[5, 5, 20], meq=0.0,
+                 m_breaks=[0.1, 0.5, 1.0, 150], nbins=[5, 5, 20],
                  tracer_masses=None, tcc=0.0, NS_ret=0.1, BH_ret_int=1.0,
+                 meq=0.0, eta=0.0, zeta=1.0,
                  esc_rate=0.0, natal_kicks=True, kick_method='maxwellian',
                  f_kick=None, SNe_method='rapid', vesc=90, kick_vdisp=265.,
                  kick_slope=1, kick_scale=20, MF_kwargs=None,
                  meanmassdef='global', ode_maxstep=1e10, ode_rtol=1e-7,
-                 diffcrit=1e-8, max_mf_iter=100):
+                 diffcrit=1e-8, max_mf_iter=100, mf_iter_index=0.5):
 
         # ------------------------------------------------------------------
         # Add/convert units of some quantities. Supports quantities as inputs
@@ -1228,6 +1229,8 @@ class Model(lp.limepy):
             rh=rh.value,
             ra=ra.value,
             delta=delta,
+            eta=eta,
+            zeta=zeta,
             mj=mj,
             Mj=Mj,
             meq=meq,
@@ -1237,7 +1240,8 @@ class Model(lp.limepy):
             max_step=ode_maxstep,
             ode_rtol=ode_rtol,
             diffcrit=diffcrit,
-            max_mf_iter=max_mf_iter
+            max_mf_iter=max_mf_iter,
+            mf_iter_index=mf_iter_index
         )
 
         try:
@@ -1738,9 +1742,10 @@ class EvolvedModel(Model):
     def __init__(self, W0, M0, rh0, g=1.5, delta=0.45, ra=1e8,
                  a1=1.3, a2=2.3, a3=2.3, d=5,
                  s2=0., F=1., *, observations=None, age=None, FeH=None,
-                 Zsun=0.02, m_breaks=[0.1, 0.5, 1.0, 100], nbins=[5, 5, 20],
+                 Zsun=0.02, m_breaks=[0.1, 0.5, 1.0, 150], nbins=[5, 5, 20],
                  tracer_masses=None, tcc=0.0, NS_ret=0.1, BH_ret_int=1.0,
-                 meq=0.0, md=1.2, natal_kicks=True, kick_method='maxwellian',
+                 meq=0.0, eta=0.0, zeta=1.0, md=1.2,
+                 natal_kicks=True, kick_method='maxwellian',
                  f_kick=None, SNe_method='rapid', kick_vdisp=265.,
                  kick_slope=1, kick_scale=20,
                  cbh_kwargs=None, MF_kwargs=None, meanmassdef='global',
@@ -1912,7 +1917,8 @@ class EvolvedModel(Model):
 
         # Explicitly specify everything so we can get the correct Signature
         super().__init__(W0, M, rh, g=g, delta=delta, ra=ra,
-                         a1=a1, a2=a2, a3=a3, BHret=BHret, d=d, meq=meq,
+                         a1=a1, a2=a2, a3=a3, BHret=BHret, d=d,
+                         meq=meq, eta=eta, zeta=zeta,
                          s2=s2, F=F, observations=observations, age=age,
                          FeH=FeH, m_breaks=m_breaks, vesc=vesc, esc_rate=Mdot_t,
                          tcc=tcc, tracer_masses=tracer_masses,

--- a/gcfit/probabilities/priors.py
+++ b/gcfit/probabilities/priors.py
@@ -744,12 +744,12 @@ class CromwellUniformPrior(_PriorBase):
 
 # TODO these defaults of course assume `compatibility_transforms=True`
 DEFAULT_PRIORS = {
-    'W0': ('uniform', [(3, 20)]),
+    'W0': ('uniform', [(0.5, 20)]),
     'M': ('uniform', [(0.01, 5)]),
     'rh': ('uniform', [(0.5, 15)]),
     'ra': ('uniform', [(0, 5)]),
     'g': ('uniform', [(0, 3.5)]),
-    'delta': ('uniform', [(0.3, 0.5)]),
+    'delta': ('uniform', [(0.1, 0.5)]),
     's2': ('uniform', [(0, 15)]),
     'F': ('uniform', [(1, 3)]),
     'a1': ('uniform', [(-1, 2.35)]),
@@ -765,12 +765,10 @@ DEFAULT_PRIORS = {
     'kick_vdisp': ('uniform', [(50, 265.)]),
     'kick_slope': ('uniform', [(1e-5, 2)]),
     'kick_scale': ('uniform', [(5, 100)]),
-    'IFMR_slope1': ('uniform', [(0.1, 10)]),
-    'IFMR_slope2': ('uniform', [(1e-6, 0.1)]),
-    'IFMR_slope3': ('uniform', [(0.01, 2)]),
-    'IFMR_scale1': ('uniform', [(-20, 20)]),
-    'IFMR_scale2': ('uniform', [(-10, 20)]),
-    'IFMR_scale3': ('uniform', [(-10, 20)])
+    #
+    'zeta': ('uniform', [(0.01, 2.0)]),
+    'eta': ('uniform', [(-5.0, 5.0)]),
+    'meq': ('uniform', [(0.0, 15.0)]),
 }
 
 _PRIORS_MAP = {

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -1100,7 +1100,7 @@ def likelihood_BH_core_radius(model, *, slope=0.5, scale=-0.5,
 
     lg_fbh = np.log10(model.f_BH.to_value('pct'))
 
-    lg_rcrh = np.log10((model.r0 / model.rh).value)
+    lg_rcrh = np.log10((model.rc_obs / model.rh).value)
 
     mu = np.nanmax([slope * lg_fbh + scale, threshold])
     sigma = width


### PR DESCRIPTION
This branch addresses two issues mainly related to the equipartition of BHs.
Firstly, the new equipartition parameter `zeta`, and the older parameter `eta` from limepy are both introduced to the models, and secondly the BH-core probability function is switched from using the "King" `r0` core radius from limepy, to a more "observable" core radius, which is much more analogous to the radii used in the CMC models.