### PR TITLE
Feature/bh rh prior

### DIFF
--- a/gcfit/core/main.py
+++ b/gcfit/core/main.py
@@ -293,7 +293,8 @@ class NestedSamplingOutput(Output):
 
 def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
              Ncpu=2, mpi=False, initials=None, param_priors=None, moves=None,
-             excluded_likelihoods=None, BH_core_constraint=False,
+             excluded_likelihoods=None,
+             BH_core_constraint=False, BH_radius_constraint=False,
              hyperparams=False,
              model_kwargs=None, cont_run=False, savedir=_here, backup=False,
              restrict_to=None, compress=False, param_transforms=None,
@@ -584,7 +585,8 @@ def MCMC_fit(cluster, Niters, Nwalkers, evolved=False, *, free_params=None,
 
         sampler_kwargs = {'hyperparams': hyperparams, 'evolved': evolved,
                           'return_indiv': True,
-                          'BH_core_likelihood': BH_core_constraint}
+                          'BH_core_likelihood': BH_core_constraint,
+                          'BH_rh_likelihood': BH_radius_constraint}
 
         sampler = emcee.EnsembleSampler(
             nwalkers=Nwalkers,
@@ -677,7 +679,7 @@ def nested_fit(cluster, evolved=False, *, free_params=None,
                bound_type='multi', sample_type='auto',
                pfrac=1.0, maxfrac=0.8, eff_samples=5000, plat_wt_func=False,
                Ncpu=2, mpi=False, param_priors=None, excluded_likelihoods=None,
-               BH_core_constraint=False,
+               BH_core_constraint=False, BH_radius_constraint=False,
                hyperparams=False, savedir=_here, restrict_to=None,
                compress=False, verbose=False, param_transforms=None):
     '''Main nested sampling fitting pipeline.
@@ -978,7 +980,8 @@ def nested_fit(cluster, evolved=False, *, free_params=None,
 
         logl_kwargs = {'hyperparams': hyperparams, 'evolved': evolved,
                        'return_indiv': False,
-                       'BH_core_likelihood': BH_core_constraint}
+                       'BH_core_likelihood': BH_core_constraint,
+                       'BH_rh_likelihood': BH_radius_constraint}
 
         sampler = dynesty.DynamicNestedSampler(
             ndim=model_params.ndim,

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -1172,7 +1172,7 @@ def likelihood_BH_radius_ratio(model, *, slope=0.4, scale=-1.4, width=0.3):
 
 
 def log_likelihood(theta, observations, model_params, L_components,
-                   hyperparams, evolved, BH_core_likelihood):
+                   hyperparams, evolved, BH_core_likelihood, BH_rh_likelihood):
     r'''Compute log likelihood of given `theta`, based on component likelihoods.
 
     Main likelihood function, which generates the relevant model based on
@@ -1262,13 +1262,16 @@ def log_likelihood(theta, observations, model_params, L_components,
     if BH_core_likelihood:
         prob_other += likelihood_BH_core_radius(model)
 
+    if BH_rh_likelihood:
+        prob_other += likelihood_BH_radius_ratio(model)
+
     return sum(probs) + prob_other, probs
 
 
 def posterior(theta, observations, model_params,
               L_components=None, prior_likelihood=None, *,
               hyperparams=False, return_indiv=True,
-              evolved=False, BH_core_likelihood=False):
+              evolved=False, BH_core_likelihood=False, BH_rh_likelihood=False):
     '''Compute the full posterior probability given `theta` and `observations`.
 
     Combines the various likelihood functions (through `log_likelihood`)
@@ -1358,7 +1361,8 @@ def posterior(theta, observations, model_params,
                                         L_components=L_components,
                                         hyperparams=hyperparams,
                                         evolved=evolved,
-                                        BH_core_likelihood=BH_core_likelihood)
+                                        BH_core_likelihood=BH_core_likelihood,
+                                        BH_rh_likelihood=BH_rh_likelihood)
 
     probability = log_L + log_Pθ
 

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -1113,6 +1113,59 @@ def likelihood_BH_core_radius(model, *, slope=0.5, scale=-0.5,
         return util.gaussian_likelihood(X_data=mu, X_model=lg_rcrh, err=sigma)
 
 
+def likelihood_BH_radius_ratio(model, *, slope=0.4, scale=-1.4, width=0.3):
+    '''A probability function based on the BH relations of Breen & Heggie 2013.
+
+    Computes a log likelihood based on the roughly linear relationship found
+    in Breen & Heggie (2013), specifically their equation 4 between
+    log(f_bh^0.6 * mbh/m^0.4) and log(rh_bh/rh).
+    The proportionality constants (given slope and scale) of this relationship
+    was determined based on the results of a grid of dynamical models
+    (CMC; Kremer+2020).  The likelihood is truncated outside 3*width from the
+    relation.
+
+    Parameters
+    ----------
+    model : gcfit.FittableModel
+        Cluster model used to compute probability distribution.
+
+    slope : float, optional
+        Slope of the linear relation. Defaults to 0.4, as based (approximately)
+        on fits to the CMC grid.
+
+    scale : float, optional
+        y-intercept of the linear relation. Defaults to -1.4, as based
+        (approximately) on fits to the CMC grid.
+
+    width : float, optional
+        Width of the evaluated Gaussian dsitribution. Defaults to 0.3,
+        roughly representing the spread in the CMC grid.
+
+    Returns
+    -------
+    float
+        Log likelihood value.
+    '''
+
+    MM = model.BH.Mj.sum() / model.nonBH.Mj.sum()
+    mm = model.BH.mavg / model.nonBH.mavg
+
+    lg_MMmm = np.log10((MM)**0.6 * (mm)**0.4)
+
+    lg_rhrh = np.log10(model.BH.rh / model.nonBH.rh)
+
+    mu = slope * lg_MMmm + scale
+
+    sigma = width
+
+    # Truncated Gaussian
+    if not ((mu - 3 * width) < lg_rhrh < (mu + 3 * width)):
+        return -np.inf
+
+    else:
+        return util.gaussian_likelihood(X_data=mu, X_model=lg_rhrh, err=sigma)
+
+
 # --------------------------------------------------------------------------
 # Composite likelihood functions
 # --------------------------------------------------------------------------

--- a/gcfit/scripts/GCfitter.py
+++ b/gcfit/scripts/GCfitter.py
@@ -142,7 +142,12 @@ def main():
 
     shared_parser.add_argument('--constrain-BH-core', dest='BH_core_constraint',
                                action='store_true',
-                               help="Use Bayesian hyperparams")
+                               help="Use extra BH-core likelihood")
+
+    shared_parser.add_argument('--constrain-BH-radius',
+                               dest='BH_radius_constraint',
+                               action='store_true',
+                               help="Use extra BH-radius ratio likelihood")
 
     shared_parser.add_argument('--hyperparams', dest='hyperparams',
                                action='store_true',


### PR DESCRIPTION
In the same vein as the BH-core prior (b9af540cdcd1f5e5add125c5e7ae9ac016ca71ac), adds a new, optional probability function based on the BH-star half-mass radius relationship, as might be expected based on [Breen & Heggie 2013](https://ui.adsabs.harvard.edu/abs/2013MNRAS.432.2779B).