### PR TITLE
Hotfix/fix area units

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -416,12 +416,16 @@ class _ClusterVisualizer:
             eqvs = util.angular_width(self.d)
 
             # Define radius-based units
-            rad_units = [
+            # TODO this starts breaking if you close a plot within the context
+            rad_units = {
                 u.def_unit('r_h', np.median(self.rh)),
                 u.def_unit('r_0', np.median(self.r0)),
                 u.def_unit('r_v', np.median(self.rv)),
                 u.def_unit('r_t', np.median(self.rt))
-            ]
+            }
+
+            rad_units = {ur for ur in rad_units if ur.name not in
+                         [equ.name for equ in u.pc.find_equivalent_units()]}
 
             with (astroviz.quantity_support(),
                   u.set_enabled_equivalencies(eqvs),

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -531,7 +531,7 @@ class _ClusterVisualizer:
         # Convert any units desired
         # ------------------------------------------------------------------
 
-        data *= scale
+        data = data * scale
 
         x_domain = self.r if x_data is None else x_data
 
@@ -3421,6 +3421,9 @@ class _ClusterVisualizer:
             # ymedian[np.isnan(ymedian)] = 1.0 << ymedian.unit
 
             ymodel = util.QuantitySpline(xmodel, ymedian)(xdata).to(ydata.unit)
+
+            if model_scale is not None:
+                ymodel *= model_scale[mass_bin]
 
             # --------------------------------------------------------------
             # compute logl

--- a/gcfit/probabilities/priors.py
+++ b/gcfit/probabilities/priors.py
@@ -588,20 +588,29 @@ class GaussianPrior(_PriorBase):
                 f'("{self.param}", {self.mu}, {self.sigma}, '
                 f'transform={self._transform})')
 
-    def __call__(self, param_val, *args, **kw):
+    def __call__(self, param_val, *args, **kwargs):
         '''Evaluate this prior function at the value `param_val`.'''
-        return self._caller(param_val)
+
+        # check that all dependants were supplied
+        if (missing_deps := set(self.dependants) - kwargs.keys()):
+            mssg = f"Missing required dependant params: {missing_deps}"
+            raise TypeError(mssg)
+
+        loc = kwargs.get(self.mu, self.mu)
+        scale = kwargs.get(self.sigma, self.sigma)
+
+        return self._caller(param_val, loc=loc, scale=scale)
 
     def __init__(self, param, mu, sigma, *, transform=False):
 
         self._transform = transform
         self.param = param
 
-        self.mu, self.sigma = mu, sigma
+        self.dependants = []
 
-        self.dist = stats.norm(loc=self.mu, scale=self.sigma)
+        self.mu, self.sigma = self._init_val(mu), self._init_val(sigma)
 
-        self._caller = self.dist.pdf if not transform else self.dist.ppf
+        self._caller = stats.norm.pdf if not transform else stats.norm.ppf
 
 
 class FunctionalUniformPrior(UniformPrior):

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -602,11 +602,11 @@ def likelihood_number_density(model, ndensity, *,
     s2 = model.theta['s2'] << u.arcmin**-4
     yerr = np.sqrt(obs_err**2 + s2)
 
-    model_r = model.r.to(obs_r.unit)
+    model_r = model.r
     model_Σ = model.Sigmaj[mass_bin] / model.mj[mass_bin]
 
     # Interpolated the model data at the measurement locations
-    interpolated = np.interp(obs_r, model_r, model_Σ).to(obs_Σ.unit)
+    interpolated = util.QuantitySpline(model_r, model_Σ)(obs_r).to(obs_Σ.unit)
 
     # Calculate K scaling factor
     K = (np.sum(obs_Σ * interpolated / yerr**2)

--- a/gcfit/util/units.py
+++ b/gcfit/util/units.py
@@ -27,22 +27,22 @@ def angular_width(D):
         return np.tan(θ / 2) * (2 * D.value)
 
     # Angular area
-    def pcsq_to_radsq(r):
+    def pcsq_to_radsq(A):
         '''Parsecs squared to radians squared.'''
-        return (1. / rad_to_pc(1)**2) * r
+        return A / D.value**2
 
-    def radsq_to_radsq(θ):
+    def radsq_to_pcsq(Ω):
         '''Radians squared to parsec squared.'''
-        return (1. / pc_to_rad(1)**2) * θ
+        return Ω * D.value**2
 
     # Inverse Angular area
-    def inv_pcsq_to_radsq(r):
+    def inv_pcsq_to_radsq(A_inv):
         '''Parsecs squared reciprocal to radians squared reciprocal.'''
-        return (rad_to_pc(1)**2) * r
+        return A_inv * D.value**2
 
-    def inv_radsq_to_radsq(θ):
+    def inv_radsq_to_radsq(Ω_inv):
         '''Radians squared reciprocal to parsecs squared reciprocal.'''
-        return (pc_to_rad(1)**2) * θ
+        return Ω_inv / D.value**2
 
     # Angular Speed
     def kms_to_asyr(vt):
@@ -55,7 +55,7 @@ def angular_width(D):
 
     return Equivalency([
         (u.pc, u.rad, pc_to_rad, rad_to_pc),
-        (u.pc**2, u.rad**2, pcsq_to_radsq, radsq_to_radsq),
+        (u.pc**2, u.rad**2, pcsq_to_radsq, radsq_to_pcsq),
         (u.pc**-2, u.rad**-2, inv_pcsq_to_radsq, inv_radsq_to_radsq),
         ((u.km / u.s), (u.arcsec / u.yr), kms_to_asyr, asyr_to_kms)
     ], 'angular_width', {"D": D})


### PR DESCRIPTION
Fix a couple important bugs, mostly related to the units, conversions and scaling.

In particular, fixes the conversion of angular to linear _area_ units (e.g. pc2 to arcsec2), which has apparently been broken for quite some time.
I'm pretty sure this is the right conversion now (based on the definition of solid angle) but the old stuff was definitely wrong.