### PR TITLE
Hotfix/update dependencies

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.9"
+    python: "3.14"
 
 # Build from the docs/ directory with Sphinx
 sphinx:

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -3780,7 +3780,8 @@ class ModelVisualizer(_ClusterVisualizer):
         self.N_WD = model.WD.Nj.sum()
         self.BH_massfunc = self.BH0_massfunc = self._init_BH_dNdm(model)[bh_slc]
         self.BH_kick_ret = self._init_kicks(model)[bh_slc]
-        self.M_kicked = model._mf._kick_stats.total_kicked << u.Msun
+        Mscale = model._MS / model._mf.M.sum()  # non-ev models need mf scaled
+        self.M_kicked = (model._mf._kick_stats.total_kicked * Mscale) << u.Msun
         self.Ms_t = model.nonBH.Mj.sum()[t_slc]
         self.mmean_t = model.mmean[t_slc]
         self.rt_t = model.rt[t_slc]
@@ -3997,9 +3998,12 @@ class ModelVisualizer(_ClusterVisualizer):
         # Spline must have no inf, so just make it large (?)
         bw[~np.isfinite(bw)] = 1000 << u.Msun
 
-        model_dN0dm = model._mf.Nr.BH / bw
+        model_dNdm = model._mf.Nr.BH / bw
 
-        bhmf_interp = util.QuantitySpline(b[:-1] + (bw / 2), model_dN0dm, k=1)
+        # Sometimes nans sneak around
+        model_dNdm[~np.isfinite(model_dNdm)] = 0. << model_dNdm.unit
+
+        bhmf_interp = util.QuantitySpline(b[:-1] + (bw / 2), model_dNdm, k=1)
 
         mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
 
@@ -4698,7 +4702,9 @@ class CIModelVisualizer(_ClusterVisualizer):
             M_BH0[model_ind] = M_BH[model_ind]
             N_BH0[model_ind] = N_BH[model_ind]
 
-            M_kicked[model_ind] = model._mf._kick_stats.total_kicked << u.Msun
+            Mscale = model._MS / model._mf.M.sum()  # scaling for non-ev eMFs
+            ks = model._mf._kick_stats
+            M_kicked[model_ind] = (ks.total_kicked * Mscale) << u.Msun
 
             bhslc = (slice(None), model_ind, 0)
             BH_massfunc[bhslc] = BH0_massfunc[bhslc] = viz._init_BH_dNdm(model)
@@ -5084,9 +5090,12 @@ class CIModelVisualizer(_ClusterVisualizer):
 
         bw[~np.isfinite(bw)] = 1000 << u.Msun
 
-        model_dN0dm = model._mf.Nr.BH / bw
+        model_dNdm = model._mf.Nr.BH / bw
 
-        bhmf_interp = util.QuantitySpline(b[:-1] + (bw / 2), model_dN0dm, k=1)
+        # Sometimes nans sneak around
+        model_dNdm[~np.isfinite(model_dNdm)] = 0. << model_dNdm.unit
+
+        bhmf_interp = util.QuantitySpline(b[:-1] + (bw / 2), model_dNdm, k=1)
 
         mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
 

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -4011,15 +4011,6 @@ class ModelVisualizer(_ClusterVisualizer):
 
         return fret
 
-        # from ssptools import kicks
-
-        # ks = model._mf._kick_stats
-        # fret = kicks._get_kick_method(model._mf_kwargs['kick_method'])
-
-        # mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
-
-        # return fret(mbh.value, **ks.parameters) << u.dimensionless_unscaled
-
 
 class CIModelVisualizer(_ClusterVisualizer):
     '''Analysis and visualization of a model, with confidence intervals.
@@ -5102,18 +5093,8 @@ class CIModelVisualizer(_ClusterVisualizer):
         return bhmf_interp(mbh)
 
     def _init_kicks(self, model):
-        # from ssptools import kicks
 
-        # This holds nans wherever kicks are not actually done (e.g. 0 BH bins)
         fret = model._mf._kick_stats.retention << u.dimensionless_unscaled
-
-        # So instead, recompute the kicks (which are really fast)
-        # ks = model._mf._kick_stats
-        # fret = kicks._get_kick_method(model._mf_kwargs['kick_method'])
-
-        # mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
-
-        # return fret(mbh.value, **ks.parameters) << u.dimensionless_unscaled
 
         return fret
 

--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -3274,7 +3274,7 @@ class _ClusterVisualizer:
     @_support_units
     def plot_BH_kick_fret(self, fig=None, ax=None, *, x_unit='Msun',
                           label_position='left', verbose_label=True,
-                          stairplot=False, **kwargs):
+                          stairplot=True, **kwargs):
         r'''Plot model BH natal kick retention fraction.
 
         Plots the retention fraction of BHs caused by natal kicks in this
@@ -3395,7 +3395,7 @@ class _ClusterVisualizer:
         else:
             label = r'$\frac{\mathrm{d}\,N}{\mathrm{d}\,m}_{BH}$'
 
-        self._set_ylabel(ax, label, self.BH_kick_ret.unit, label_position)
+        self._set_ylabel(ax, label, None, label_position)
         self._set_xlabel(ax, r'$m_{\mathrm{BH}}$', unit=x_unit)
 
         return fig
@@ -3718,6 +3718,7 @@ class ModelVisualizer(_ClusterVisualizer):
 
         self.r = model.r
         self.t = [model.age] << u.Gyr
+        # TODO uppermost BH bin edge will often be inf, causing plot issues
         self._mbh_edges = np.r_[model._mf.massbins.bins.BH.lower,
                                 model._mf.massbins.bins.BH.upper[-1]] << u.Msun
 
@@ -3993,6 +3994,9 @@ class ModelVisualizer(_ClusterVisualizer):
         b = np.r_[BH_bins.lower, BH_bins.upper[-1]] << u.Msun
         bw = (BH_bins.upper - BH_bins.lower) << u.Msun
 
+        # Spline must have no inf, so just make it large (?)
+        bw[~np.isfinite(bw)] = 1000 << u.Msun
+
         model_dN0dm = model._mf.Nr.BH / bw
 
         bhmf_interp = util.QuantitySpline(b[:-1] + (bw / 2), model_dN0dm, k=1)
@@ -4002,14 +4006,19 @@ class ModelVisualizer(_ClusterVisualizer):
         return bhmf_interp(mbh)
 
     def _init_kicks(self, model):
-        from ssptools import kicks
 
-        ks = model._mf._kick_stats
-        fret = kicks._get_kick_method(model._mf_kwargs['kick_method'])
+        fret = model._mf._kick_stats.retention << u.dimensionless_unscaled
 
-        mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
+        return fret
 
-        return fret(mbh.value, **ks.parameters) << u.dimensionless_unscaled
+        # from ssptools import kicks
+
+        # ks = model._mf._kick_stats
+        # fret = kicks._get_kick_method(model._mf_kwargs['kick_method'])
+
+        # mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
+
+        # return fret(mbh.value, **ks.parameters) << u.dimensionless_unscaled
 
 
 class CIModelVisualizer(_ClusterVisualizer):
@@ -5082,6 +5091,8 @@ class CIModelVisualizer(_ClusterVisualizer):
         b = np.r_[BH_bins.lower, BH_bins.upper[-1]] << u.Msun
         bw = (BH_bins.upper - BH_bins.lower) << u.Msun
 
+        bw[~np.isfinite(bw)] = 1000 << u.Msun
+
         model_dN0dm = model._mf.Nr.BH / bw
 
         bhmf_interp = util.QuantitySpline(b[:-1] + (bw / 2), model_dN0dm, k=1)
@@ -5091,18 +5102,20 @@ class CIModelVisualizer(_ClusterVisualizer):
         return bhmf_interp(mbh)
 
     def _init_kicks(self, model):
-        from ssptools import kicks
+        # from ssptools import kicks
 
         # This holds nans wherever kicks are not actually done (e.g. 0 BH bins)
-        # model_ret = model._mf._kick_stats['retention']
+        fret = model._mf._kick_stats.retention << u.dimensionless_unscaled
 
         # So instead, recompute the kicks (which are really fast)
-        ks = model._mf._kick_stats
-        fret = kicks._get_kick_method(model._mf_kwargs['kick_method'])
+        # ks = model._mf._kick_stats
+        # fret = kicks._get_kick_method(model._mf_kwargs['kick_method'])
 
-        mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
+        # mbh = 0.5 * (self._mbh_edges[1:] + self._mbh_edges[:-1])
 
-        return fret(mbh.value, **ks.parameters) << u.dimensionless_unscaled
+        # return fret(mbh.value, **ks.parameters) << u.dimensionless_unscaled
+
+        return fret
 
     # ----------------------------------------------------------------------
     # Save and load confidence intervals to a file
@@ -5712,9 +5725,12 @@ class EvolvedVisualizer(ModelVisualizer):
 
     def _init_BH_dN0dm(self, model):
 
+        # clusterbh ibh should match mf ibh, but with natal kicks applied
         BH_bins = model._clusterbh.ibh.bins
         b = np.r_[BH_bins.lower, BH_bins.upper[-1]] << u.Msun
         bw = (BH_bins.upper - BH_bins.lower) << u.Msun
+
+        bw[~np.isfinite(bw)] = 1000 << u.Msun
 
         model_dN0dm = model._clusterbh.ibh.N / bw
 

--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -41,6 +41,7 @@ _label_math_mapping = {
     'a2': r'\alpha_2',
     'a3': r'\alpha_3',
     'BHret': r'\mathrm{BH}_{ret}',
+    'BH_ret_dyn': r'\mathrm{BH}_{\mathrm{ret},\mathrm{dyn}}',
     'd': r'd',
     # Evolved Model Parameters
     'M0': r'M_{0}',
@@ -94,6 +95,7 @@ _label_unit_mapping = {
     'rhoh0': r'M_\odot\ \mathrm{pc^{-3}}',
     's2': r'\mathrm{arcmin^{-4}}',
     'BHret': r'\%',
+    'BH_ret_dyn': r'\%',
     'd': r'\mathrm{kpc}',
     'Ndot': r'\dot{N}',
     'RA': r'\deg',

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1110,7 +1110,8 @@ class Model(lp.limepy):
                  f_kick=None, SNe_method='rapid', vesc=90, kick_vdisp=265.,
                  kick_slope=1, kick_scale=20, MF_kwargs=None,
                  meanmassdef='global', ode_maxstep=1e10, ode_rtol=1e-7,
-                 diffcrit=1e-8, max_mf_iter=100, mf_iter_index=0.5):
+                 diffcrit=1e-3, max_mf_iter=100, mf_iter_index=0.5,
+                 diffdef='rel'):
 
         # ------------------------------------------------------------------
         # Add/convert units of some quantities. Supports quantities as inputs
@@ -1252,7 +1253,8 @@ class Model(lp.limepy):
             ode_rtol=ode_rtol,
             diffcrit=diffcrit,
             max_mf_iter=max_mf_iter,
-            mf_iter_index=mf_iter_index
+            mf_iter_index=mf_iter_index,
+            diffdef=diffdef
         )
 
         try:
@@ -1797,8 +1799,8 @@ class EvolvedModel(Model):
                  f_kick=None, SNe_method='rapid', kick_vdisp=265.,
                  kick_slope=1, kick_scale=20,
                  cbh_kwargs=None, MF_kwargs=None, meanmassdef='global',
-                 ode_maxstep=1e10, ode_rtol=1e-7, diffcrit=1e-8,
-                 max_mf_iter=100, mf_iter_index=0.5):
+                 ode_maxstep=1e10, ode_rtol=1e-7, diffcrit=1e-3,
+                 max_mf_iter=100, mf_iter_index=0.5, diffdef='rel'):
         import clusterbh
 
         M0 <<= u.Msun
@@ -1992,7 +1994,8 @@ class EvolvedModel(Model):
                          kick_scale=kick_scale, meanmassdef=meanmassdef,
                          ode_maxstep=ode_maxstep, ode_rtol=ode_rtol,
                          diffcrit=diffcrit, max_mf_iter=max_mf_iter,
-                         mf_iter_index=mf_iter_index, MF_kwargs=MF_kwargs)
+                         mf_iter_index=mf_iter_index, MF_kwargs=MF_kwargs,
+                         diffdef=diffdef)
 
         # reset theta to use initial values
         self.theta = dict(W0=W0, M0=M0.to_value('1e6 Msun'), rh0=rh0.value,

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1808,7 +1808,8 @@ class EvolvedModel(Model):
                  cbh_kwargs=None, MF_kwargs=None, meanmassdef='global',
                  ode_maxstep=1e10, ode_rtol=1e-7, diffcrit=1e-3,
                  max_mf_iter=100, mf_iter_index=0.5, diffdef='rel'):
-        import clusterbh
+
+        import cbhbd
 
         M0 <<= u.Msun
         rh0 <<= u.pc
@@ -1924,6 +1925,7 @@ class EvolvedModel(Model):
         # clusterBH fit parameters should use defaults, or given in cbh_kwargs
         # ------------------------------------------------------------------
 
+        cbh_kwargs.setdefault('dtout', 2.0)
         cbh_kwargs.setdefault('ssp', True)
         cbh_kwargs.setdefault('kick', True)
         cbh_kwargs.setdefault('tidal', True)
@@ -1944,8 +1946,9 @@ class EvolvedModel(Model):
 
         self.cbh_kwargs = cbh_kwargs
 
-        self._clusterbh = clusterbh.clusterBH(N0, self.rhoh0.value,
-                                              **self.cbh_kwargs)
+        self._clusterbh = cbhbd.cbhbd.CBHBD(N=N0, rhoh0=self.rhoh0.value,
+                                            compute_mergers=False,
+                                            **self.cbh_kwargs).cluster
 
         # Make sure no negative f_BH values are allowed
         self._clusterbh.fbh[self._clusterbh.fbh < 0] = 0.
@@ -1971,7 +1974,8 @@ class EvolvedModel(Model):
                    / self._clusterbh.tev)
 
         # Ejection
-        bf = self._clusterbh.balance_function(self._clusterbh.t)
+        bf = self._clusterbh.balance_function((self._clusterbh.t * 1e3) - tcc)
+
         alpha_c = (self._clusterbh.alpha_ci * bf)
         alpha_c += ((self._clusterbh.alpha_cf * bf - alpha_c)
                     * (1 - self._clusterbh.beta_function(self._clusterbh.S)))

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -21,7 +21,7 @@ __all__ = ['DEFAULT_FREE_PARAMS', 'DEFAULT_FREE_EV_PARAMS',
 
 DEFAULT_FREE_PARAMS = (
     'W0', 'M', 'rh', 'ra', 'g', 'delta',
-    's2', 'F', 'a1', 'a2', 'a3', 'BHret', 'd',
+    's2', 'F', 'a1', 'a2', 'a3', 'BH_ret_dyn', 'd',
 )
 
 DEFAULT_FREE_EV_PARAMS = (
@@ -800,10 +800,10 @@ class Model(lp.limepy):
         The high-mass IMF exponent (representing masses between
         `m_breaks[2:4]`). Defaults to 2.3, matching Kroupa (2001).
 
-    BHret : float, optional
-        The black hole retention fraction, representing the percentage (between
-        0 and 100) of black holes retained after dynamical ejections and natal
-        kicks.
+    BH_ret_dyn : float, optional
+        The dynamical black hole retention fraction, representing the percentage
+        (between 0 and 100) of black holes retained after dynamical ejections.
+        Note this does *not* include natal kicks. See `ssptools` for details.
 
     d : float or astropy.Quantity, optional
         Distance to the cluster, from Earth, in kiloparsecs. Mainly used for any
@@ -992,7 +992,7 @@ class Model(lp.limepy):
             return "Model"
 
     def _evolve_mf(self, m_breaks, a1, a2, a3, nbins, FeH, age, esc_rate, tcc,
-                   NS_ret, BH_ret_int, BHret, natal_kicks, vesc,
+                   NS_ret, BH_ret_dyn, natal_kicks, vesc,
                    kick_method, f_kick, SNe_method, kick_vdisp,
                    kick_slope,  kick_scale, **kwargs):
         '''Compute an evolved mass function using `ssptools.EvolvedMF`'''
@@ -1010,8 +1010,7 @@ class Model(lp.limepy):
             esc_rate=esc_rate,
             tcc=tcc,
             NS_ret=NS_ret,
-            BH_ret_int=BH_ret_int,
-            BH_ret_dyn=BHret / 100.,
+            BH_ret_dyn=BH_ret_dyn / 100.,
             natal_kicks=natal_kicks,
             vesc=vesc.value,
             kick_method=kick_method,
@@ -1102,7 +1101,7 @@ class Model(lp.limepy):
                            rhoj=rhoj, Sigmaj=Sigmaj, f=f, rh=rh)
 
     def __init__(self, W0, M, rh, g=1.5, delta=0.45, ra=1e8,
-                 a1=1.3, a2=2.3, a3=2.3, BHret=5.0, d=5,
+                 a1=1.3, a2=2.3, a3=2.3, BH_ret_dyn=5.0, d=5,
                  s2=0., F=1., J=1., *, observations=None, age=None, FeH=None,
                  m_breaks=[0.1, 0.5, 1.0, 150], nbins=[5, 5, 20],
                  tracer_masses=None, tcc=0.0, NS_ret=0.1, BH_ret_int=1.0,
@@ -1131,7 +1130,7 @@ class Model(lp.limepy):
 
         self.theta = dict(W0=W0.value, M=M.to_value('1e6 Msun'), rh=rh.value,
                           ra=np.log10(ra.value), g=g, delta=delta,
-                          a1=a1, a2=a2, a3=a3, BHret=BHret,
+                          a1=a1, a2=a2, a3=a3, BH_ret_dyn=BH_ret_dyn,
                           s2=s2, F=F, J=J, d=d.value)
 
         self.d = d
@@ -1181,7 +1180,7 @@ class Model(lp.limepy):
 
         self._mf = self._evolve_mf(m_breaks, a1, a2, a3, nbins,
                                    self.FeH, self.age, esc_rate, tcc,
-                                   NS_ret, BH_ret_int, BHret,
+                                   NS_ret, BH_ret_dyn,
                                    natal_kicks, self.vesc0,
                                    kick_method, f_kick, SNe_method, kick_vdisp,
                                    kick_slope,  kick_scale, **MF_kwargs)
@@ -1265,6 +1264,7 @@ class Model(lp.limepy):
 
                 mssg = (f"Model extent is not finite (rt>{self.rt:.2f}). "
                         "Model parameters must be adjusted")
+
                 raise ValueError(mssg) from err
 
             elif "ode not successful" in cause:
@@ -1756,7 +1756,7 @@ class EvolvedModel(Model):
     '''
 
     def _evolve_mf(self, m_breaks, a1, a2, a3, nbins, FeH, age, esc_rate, tcc,
-                   NS_ret, BH_ret_int, BHret, natal_kicks, vesc,
+                   NS_ret, BH_ret_dyn, natal_kicks, vesc,
                    kick_method, f_kick, SNe_method, kick_vdisp,
                    kick_slope,  kick_scale, **kwargs):
         '''Alternative MF init using prior-computed IMF and clusterBH outputs'''
@@ -1772,7 +1772,6 @@ class EvolvedModel(Model):
             N0=self._clusterbh.N,  # N is N0
             tcc=tcc,
             NS_ret=NS_ret,
-            BH_ret_int=BH_ret_int,
             natal_kicks=natal_kicks,
             vesc=vesc.value,
             esc_norm='M',
@@ -1976,11 +1975,11 @@ class EvolvedModel(Model):
             mssg = f'Too few clusterBH timesteps created: t={self._clusterbh.t}'
             raise ValueError(mssg)
 
-        BHret = -1  # Spoof unneeded BH retention fraction for `Model`
+        BH_ret_dyn = -1  # Spoof unneeded BH retention fraction for `Model`
 
         # Explicitly specify everything so we can get the correct Signature
         super().__init__(W0, M, rh, g=g, delta=delta, ra=ra,
-                         a1=a1, a2=a2, a3=a3, BHret=BHret, d=d,
+                         a1=a1, a2=a2, a3=a3, BH_ret_dyn=BH_ret_dyn, d=d,
                          meq=meq, eta=eta, zeta=zeta,
                          s2=s2, F=F, J=J, observations=observations, age=age,
                          FeH=FeH, m_breaks=m_breaks, nbins=nbins,
@@ -1998,7 +1997,7 @@ class EvolvedModel(Model):
         # reset theta to use initial values
         self.theta = dict(W0=W0, M0=M0.to_value('1e6 Msun'), rh0=rh0.value,
                           ra=np.log10(ra), g=g, delta=delta,
-                          a1=a1, a2=a2, a3=a3, BHret=BHret,
+                          a1=a1, a2=a2, a3=a3, BH_ret_dyn=BH_ret_dyn,
                           s2=s2, F=F, J=J, d=d.value)
 
     def get_visualizer(self):

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -1108,8 +1108,10 @@ class Model(lp.limepy):
                  meq=0.0, eta=0.0, zeta=1.0,
                  esc_rate=0.0, natal_kicks=True, kick_method='maxwellian',
                  f_kick=None, SNe_method='rapid', vesc=90, kick_vdisp=265.,
-                 kick_slope=1, kick_scale=20, MF_kwargs=None,
-                 meanmassdef='global', ode_maxstep=1e10, ode_rtol=1e-7,
+                 kick_slope=1, kick_scale=20,
+                 BH_IFMR_method='banerjee20', BH_IFMR_kwargs=None,
+                 MF_kwargs=None, meanmassdef='global',
+                 ode_maxstep=1e10, ode_rtol=1e-7,
                  diffcrit=1e-3, max_mf_iter=100, mf_iter_index=0.5,
                  diffdef='rel'):
 
@@ -1184,7 +1186,8 @@ class Model(lp.limepy):
                                    NS_ret, BH_ret_dyn,
                                    natal_kicks, self.vesc0,
                                    kick_method, f_kick, SNe_method, kick_vdisp,
-                                   kick_slope,  kick_scale, **MF_kwargs)
+                                   kick_slope,  kick_scale,
+                                   BH_IFMR_method, BH_IFMR_kwargs, **MF_kwargs)
 
         if not self._mf.converged:
             mssg = ("Mass function evolution ODE failed to converge"
@@ -1760,7 +1763,8 @@ class EvolvedModel(Model):
     def _evolve_mf(self, m_breaks, a1, a2, a3, nbins, FeH, age, esc_rate, tcc,
                    NS_ret, BH_ret_dyn, natal_kicks, vesc,
                    kick_method, f_kick, SNe_method, kick_vdisp,
-                   kick_slope,  kick_scale, **kwargs):
+                   kick_slope,  kick_scale, BH_IFMR_method, BH_IFMR_kwargs,
+                   **kwargs):
         '''Alternative MF init using prior-computed IMF and clusterBH outputs'''
         from ssptools import EvolvedMFWithBH
 
@@ -1784,6 +1788,8 @@ class EvolvedModel(Model):
             kick_vdisp=kick_vdisp,
             kick_slope=kick_slope,
             kick_scale=kick_scale,
+            BH_IFMR_method=BH_IFMR_method,
+            BH_IFMR_kwargs=BH_IFMR_kwargs,
             **kwargs  # will error here if MF_kwargs included any of above args
         )
 
@@ -1798,6 +1804,7 @@ class EvolvedModel(Model):
                  natal_kicks=True, kick_method='maxwellian',
                  f_kick=None, SNe_method='rapid', kick_vdisp=265.,
                  kick_slope=1, kick_scale=20,
+                 BH_IFMR_method='banerjee20', BH_IFMR_kwargs=None,
                  cbh_kwargs=None, MF_kwargs=None, meanmassdef='global',
                  ode_maxstep=1e10, ode_rtol=1e-7, diffcrit=1e-3,
                  max_mf_iter=100, mf_iter_index=0.5, diffdef='rel'):
@@ -1821,9 +1828,12 @@ class EvolvedModel(Model):
         # Make sure the relevant kickparams are passed to clusterBH by default
         # but still respect any explicitly passed in `ibh_kwargs` too
 
-        ibh_kwargs = dict(kick_method=kick_method, f_kick=f_kick,
-                          SNe_method=SNe_method, kick_vdisp=kick_vdisp,
-                          kick_slope=kick_slope, kick_scale=kick_scale)
+        ibh_kwargs = dict(
+            kick_method=kick_method, f_kick=f_kick,
+            SNe_method=SNe_method, kick_vdisp=kick_vdisp,
+            kick_slope=kick_slope, kick_scale=kick_scale,
+            BH_IFMR_method=BH_IFMR_method, BH_IFMR_kwargs=BH_IFMR_kwargs
+        )
 
         ibh_kwargs |= cbh_kwargs.get('ibh_kwargs', {}).copy()
 

--- a/gcfit/core/data.py
+++ b/gcfit/core/data.py
@@ -994,7 +994,8 @@ class Model(lp.limepy):
     def _evolve_mf(self, m_breaks, a1, a2, a3, nbins, FeH, age, esc_rate, tcc,
                    NS_ret, BH_ret_dyn, natal_kicks, vesc,
                    kick_method, f_kick, SNe_method, kick_vdisp,
-                   kick_slope,  kick_scale, **kwargs):
+                   kick_slope,  kick_scale, BH_IFMR_method, BH_IFMR_kwargs,
+                   **kwargs):
         '''Compute an evolved mass function using `ssptools.EvolvedMF`'''
 
         # Total mass of this will be wrong due to N0 but Mj is scaled in limepy
@@ -1019,6 +1020,8 @@ class Model(lp.limepy):
             kick_vdisp=kick_vdisp,
             kick_slope=kick_slope,
             kick_scale=kick_scale,
+            BH_IFMR_method=BH_IFMR_method,
+            BH_IFMR_kwargs=BH_IFMR_kwargs,
             **kwargs  # will error here if MF_kwargs included any of above args
         )
 

--- a/gcfit/probabilities/priors.py
+++ b/gcfit/probabilities/priors.py
@@ -653,6 +653,10 @@ class FunctionalUniformPrior(UniformPrior):
     *not* be applied. This may change how the bounding functions must be
     written, to account for this.
 
+    For example, a prior on `rh0` which sets bounds on the initial
+    density of 1e2<rhoh0<1e7 would look like:
+    "(3*M0*1e6 / (8*pi*1e7))**(1/3)" to "(3*M0*1e6 / (8*pi*1e2))**(1/3)".
+
     This function uses `sympy.lambdify` to convert the symbolic functions to
     python function, and thus is *not* safe for use on unsanitized inputs.
 
@@ -753,10 +757,10 @@ class CromwellUniformPrior(_PriorBase):
 
 # TODO these defaults of course assume `compatibility_transforms=True`
 DEFAULT_PRIORS = {
-    'W0': ('uniform', [(0.1, 20)]),
+    'W0': ('uniform', [(0.001, 100)]),
     'M': ('uniform', [(0.01, 5)]),
     'rh': ('uniform', [(0.5, 15)]),
-    'ra': ('uniform', [(0, 5)]),
+    'ra': ('uniform', [(-2, 8)]),
     'g': ('uniform', [(0, 3.5)]),
     'delta': ('uniform', [(0.1, 0.5)]),
     's2': ('uniform', [(0, 15)]),
@@ -765,7 +769,7 @@ DEFAULT_PRIORS = {
     'a1': ('uniform', [(-1, 2.35)]),
     'a2': ('uniform', [(-1, 2.35), ('a1', np.inf)]),
     'a3': ('uniform', [(1.6, 4), ('a2', np.inf)]),
-    'BHret': ('uniform', [(0, 100)]),
+    'BH_ret_dyn': ('uniform', [(0, 100)]),
     'd': ('uniform', [(2, 18)]),
     #
     'M0': ('uniform', [(0.001, 10)]),

--- a/gcfit/probabilities/probabilities.py
+++ b/gcfit/probabilities/probabilities.py
@@ -1287,7 +1287,7 @@ def posterior(theta, observations, model_params,
     ----------
     theta : np.ndarray
         An array of model input parameters, which must be in the expected order
-        (W0, M, rh, ra, g, delta, a1, a2, a3, BHret, s2, F and d).
+        (W0, M, rh, ra, g, delta, a1, a2, a3, BH_ret_dyn, s2, F and d).
         Only parameters which are specified in `fixed_initials` may be excluded
         here. A dictionary of parameters is not allowed.
 

--- a/gcfit/scripts/GCfitter.py
+++ b/gcfit/scripts/GCfitter.py
@@ -110,7 +110,7 @@ def main():
                                     '(or --model-kwargs) values. By default '
                                     'the 13 typical free parameters will be '
                                     'used (W0, M/1e6, rh, log(ra), g, delta, '
-                                    's2, F, a1, a2, a3, BHret, d).')
+                                    's2, F, a1, a2, a3, BH_ret_dyn, d).')
 
     shared_parser.add_argument('--restrict-to', default=None,
                                choices={None, 'local', 'core'},

--- a/gcfit/util/probabilities.py
+++ b/gcfit/util/probabilities.py
@@ -143,6 +143,8 @@ class ModelParameters:
         to the relevant free parameters when given to the one of the argument
         building methods. Necessary if, for example, you wish to vary the log
         of a parameter, rather than the parameter itself.
+        Note that these transforms are only applied to free parameters, not
+        those given in `model_kwargs`.
 
     sympy_transforms : bool, optional
         Flag allowing the passed transforms to be strings parseable by sympy,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "GCfit"
-version = "3.1.2"
+version = "3.2.0"
 description = "Fitting of multimass equilibrium models of globular clusters"
 authors = [
     {name = "Nolan Dickson", email = "nolan.dickson@smu.ca"},
@@ -8,15 +8,15 @@ authors = [
     {name = "Vincent Henault-Brunet", email= "Vincent.Henault@smu.ca"}
 ]
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 keywords = ["GCfit", "Globular Cluster", "Star Cluster"]
 license = {file = "LICENSE"}
 dependencies = [
     "numpy",
     "scipy",
     "astropy",
-    "astro-limepy",
-    "astro-ssptools",
+    "astro-limepy>=1.3.0",
+    "astro-ssptools>=3.0.0",
     "emcee",
     "dynesty>=3.0.0",
     "h5py",


### PR DESCRIPTION
This update is about bringing a few important dependencies up to date.

- Limepy version requirements are updated to make sure we are using all the latest equipartition and related fixes from [limepy#22](https://github.com/mgieles/limepy/pull/22) (v1.3.0).

- SSPtools is updated to use all the changes to the kicks completed in [ssptools#18](https://github.com/SMU-clusters/ssptools/pull/18) and to allow for using the various new IFMRs (v3.1.0)

- clusterBH is now being imported and used from the cBHBd package, not the standalone un-updated clusterBH package.