### PR TITLE
fix numdens plotting with tracer bins in CIModelVisualizer

### DIFF
--- a/gcfit/analysis/models.py
+++ b/gcfit/analysis/models.py
@@ -4515,7 +4515,7 @@ class CIModelVisualizer(_ClusterVisualizer):
 
         # number density
 
-        numdens = np.full((1, N, Nr), np.nan) << u.pc**-2
+        numdens = np.full((Nm, N, Nr), np.nan) << u.pc**-2
         # K_scale = np.full((1,), np.nan) << u.dimensionless_unscaled
         K_scale = np.full((Nm), np.nan) << u.dimensionless_unscaled
 


### PR DESCRIPTION
numdens was allocated with a hardcoded first dimension of 1 instead of Nm, causing an IndexError when any tracer bins were present. Looks like CIEvolvedVisualizer already used Nm, this just brings CIModelVisualizer in line with it.