### PR TITLE
fix NameError in NestedRun.plot_params by uncommenting gs_kw

### DIFF
--- a/gcfit/analysis/runs.py
+++ b/gcfit/analysis/runs.py
@@ -3119,7 +3119,7 @@ class NestedRun(_SingleRunAnalysis):
             mssg = "`ylims` must match number of params"
             raise ValueError(mssg)
 
-        # gs_kw = {}
+        gs_kw = {}
 
         # Determine shapes for constructing subplots/subfigures
 


### PR DESCRIPTION
fix NameError in NestedRun.plot_params by uncommenting `gs_kw` default

`gs_kw = {}` was left commented out when the show_weight height-ratio feature was marked as TODO